### PR TITLE
feat: add UI model selector with persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,36 @@ local LLM about that exact selection.
 * A model pulled in Ollama (e.g. `llama3.1`, `qwen2.5-coder`, `mistral`).
   Configure model/URL in `ollama_client.py`.
 
+### Running multiple models
+
+LocalPilot lists models that are currently **running**. If none are active you'll see “No Ollama models running” and chat is disabled.
+
+1. Allow more than one model to stay loaded:
+
+   ```bash
+   OLLAMA_MAX_LOADED_MODELS=2 ollama serve
+   ```
+
+2. Start (or "warm up") each model you plan to use:
+
+   ```bash
+   ollama run llama3 &
+   ollama run qwen2.5-coder &
+   ```
+
+3. Inspect which models are running:
+
+   ```bash
+   ollama ps
+   # or
+   curl http://localhost:11434/api/ps
+   ```
+
+   LocalPilot queries the same `/ps` endpoint for the model selector.
+
+You can also override the selector with a comma-separated `MODEL_LIST` environment variable if you prefer a static list.
+During chat the terminal running LocalPilot prints the requested model and the model reported by Ollama so you can verify which one handled the response.
+
 ---
 
 ## Quick start (90 seconds)

--- a/README.md
+++ b/README.md
@@ -30,36 +30,6 @@ local LLM about that exact selection.
 * A model pulled in Ollama (e.g. `llama3.1`, `qwen2.5-coder`, `mistral`).
   Configure model/URL in `ollama_client.py`.
 
-### Running multiple models
-
-LocalPilot lists models that are currently **running**. If none are active you'll see “No Ollama models running” and chat is disabled.
-
-1. Allow more than one model to stay loaded:
-
-   ```bash
-   OLLAMA_MAX_LOADED_MODELS=2 ollama serve
-   ```
-
-2. Start (or "warm up") each model you plan to use:
-
-   ```bash
-   ollama run llama3 &
-   ollama run qwen2.5-coder &
-   ```
-
-3. Inspect which models are running:
-
-   ```bash
-   ollama ps
-   # or
-   curl http://localhost:11434/api/ps
-   ```
-
-   LocalPilot queries the same `/ps` endpoint for the model selector.
-
-You can also override the selector with a comma-separated `MODEL_LIST` environment variable if you prefer a static list.
-During chat the terminal running LocalPilot prints the requested model and the model reported by Ollama so you can verify which one handled the response.
-
 ---
 
 ## Quick start (90 seconds)

--- a/config.py
+++ b/config.py
@@ -1,6 +1,15 @@
 """Runtime configuration for the local assistant."""
+import os
+
 # Model/runtime
-MODEL = "qwen2.5-coder:14b"
+# Comma-separated list of available models. Default falls back to ``qwen2.5-coder:14b``.
+MODEL_LIST = [
+    m.strip()
+    for m in os.environ.get("MODEL_LIST", "qwen2.5-coder:14b").split(",")
+    if m.strip()
+]
+# Default model, overridable via ``MODEL`` env var or first entry in ``MODEL_LIST``.
+MODEL = os.environ.get("MODEL", MODEL_LIST[0])
 TEMP = 0.2
 
 # Ollama HTTP endpoints

--- a/config.py
+++ b/config.py
@@ -1,19 +1,58 @@
 """Runtime configuration for the local assistant."""
 import os
+import requests
 
+
+# ---------------------------------------------------------------------------
+# Ollama HTTP endpoints
+
+OLLAMA_BASE_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434/api")
+OLLAMA_CHAT_URL = f"{OLLAMA_BASE_URL}/chat"
+OLLAMA_TAGS_URL = f"{OLLAMA_BASE_URL}/tags"
+
+
+# ---------------------------------------------------------------------------
 # Model/runtime
-# Comma-separated list of available models. Default falls back to ``qwen2.5-coder:14b``.
-MODEL_LIST = [
-    m.strip()
-    for m in os.environ.get("MODEL_LIST", "qwen2.5-coder:14b").split(",")
-    if m.strip()
-]
+
+
+def _fetch_models() -> list[str]:
+    """Return a list of available models.
+
+    Preference order:
+    1. ``MODEL_LIST`` environment variable (comma separated)
+    2. Query the local Ollama instance for installed models
+    3. Fallback to the default ``qwen2.5-coder:14b``
+    """
+
+    env = os.environ.get("MODEL_LIST")
+    if env:
+        models = [m.strip() for m in env.split(",") if m.strip()]
+        if models:
+            return models
+
+    try:
+        r = requests.get(OLLAMA_TAGS_URL, timeout=1)
+        r.raise_for_status()
+        data = r.json()
+        models = []
+        for m in data.get("models", []):
+            name = m.get("name") or m.get("model")
+            if name:
+                models.append(name)
+        if models:
+            return models
+    except Exception:
+        pass
+
+    return ["qwen2.5-coder:14b"]
+
+
+MODEL_LIST = _fetch_models()
+
 # Default model, overridable via ``MODEL`` env var or first entry in ``MODEL_LIST``.
 MODEL = os.environ.get("MODEL", MODEL_LIST[0])
 TEMP = 0.2
 
-# Ollama HTTP endpoints
-OLLAMA_CHAT_URL = "http://localhost:11434/api/chat"
 
 # Context window for chat requests (increase if you pin long code)
 NUM_CTX = 16384  # adjust build/model supports it

--- a/config.py
+++ b/config.py
@@ -1,15 +1,14 @@
 """Runtime configuration for the local assistant."""
 import os
-import requests
 
+import requests
 
 # ---------------------------------------------------------------------------
 # Ollama HTTP endpoints
 
 OLLAMA_BASE_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434/api")
 OLLAMA_CHAT_URL = f"{OLLAMA_BASE_URL}/chat"
-# running models (equivalent to `ollama ps`)
-OLLAMA_PS_URL = f"{OLLAMA_BASE_URL}/ps"
+OLLAMA_TAGS_URL = f"{OLLAMA_BASE_URL}/tags"
 
 
 # ---------------------------------------------------------------------------
@@ -21,7 +20,7 @@ def _fetch_models() -> list[str]:
 
     Preference order:
     1. ``MODEL_LIST`` environment variable (comma separated)
-    2. Query the local Ollama instance for *running* models via ``/ps``
+    2. Query the local Ollama instance for models
     """
 
     env = os.environ.get("MODEL_LIST")
@@ -31,7 +30,7 @@ def _fetch_models() -> list[str]:
             return models
 
     try:
-        r = requests.get(OLLAMA_PS_URL, timeout=1)
+        r = requests.get(OLLAMA_TAGS_URL, timeout=1)
         r.raise_for_status()
         data = r.json()
         models = []
@@ -39,16 +38,17 @@ def _fetch_models() -> list[str]:
             name = m.get("name") or m.get("model")
             if name:
                 models.append(name)
-        return models
+        if models:
+            return models
     except Exception:
-        return []
+        pass
+
+    return []
 
 
 MODEL_LIST = _fetch_models()
 
-# Default model, overridable via ``MODEL`` env var or first entry in ``MODEL_LIST``.
-# If none are running and ``MODEL`` is unset, the app will surface an error.
-MODEL = os.environ.get("MODEL", MODEL_LIST[0] if MODEL_LIST else "")
+MODEL = MODEL_LIST[0] if MODEL_LIST else []
 TEMP = 0.2
 
 

--- a/config.py
+++ b/config.py
@@ -8,7 +8,8 @@ import requests
 
 OLLAMA_BASE_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434/api")
 OLLAMA_CHAT_URL = f"{OLLAMA_BASE_URL}/chat"
-OLLAMA_TAGS_URL = f"{OLLAMA_BASE_URL}/tags"
+# running models (equivalent to `ollama ps`)
+OLLAMA_PS_URL = f"{OLLAMA_BASE_URL}/ps"
 
 
 # ---------------------------------------------------------------------------
@@ -20,8 +21,7 @@ def _fetch_models() -> list[str]:
 
     Preference order:
     1. ``MODEL_LIST`` environment variable (comma separated)
-    2. Query the local Ollama instance for installed models
-    3. Fallback to the default ``qwen2.5-coder:14b``
+    2. Query the local Ollama instance for *running* models via ``/ps``
     """
 
     env = os.environ.get("MODEL_LIST")
@@ -31,7 +31,7 @@ def _fetch_models() -> list[str]:
             return models
 
     try:
-        r = requests.get(OLLAMA_TAGS_URL, timeout=1)
+        r = requests.get(OLLAMA_PS_URL, timeout=1)
         r.raise_for_status()
         data = r.json()
         models = []
@@ -39,18 +39,16 @@ def _fetch_models() -> list[str]:
             name = m.get("name") or m.get("model")
             if name:
                 models.append(name)
-        if models:
-            return models
+        return models
     except Exception:
-        pass
-
-    return ["qwen2.5-coder:14b"]
+        return []
 
 
 MODEL_LIST = _fetch_models()
 
 # Default model, overridable via ``MODEL`` env var or first entry in ``MODEL_LIST``.
-MODEL = os.environ.get("MODEL", MODEL_LIST[0])
+# If none are running and ``MODEL`` is unset, the app will surface an error.
+MODEL = os.environ.get("MODEL", MODEL_LIST[0] if MODEL_LIST else "")
 TEMP = 0.2
 
 

--- a/ollama_client.py
+++ b/ollama_client.py
@@ -2,23 +2,24 @@ import json
 import queue
 import requests
 
-OLLAMA_URL = "http://localhost:11434/api/generate"
-MODEL = "qwen2.5-coder:14b"
-TEMP = 0.2
+from config import MODEL, OLLAMA_BASE_URL, TEMP
 
+OLLAMA_URL = f"{OLLAMA_BASE_URL}/generate"
 
-def stream_ollama(prompt: str, out_q: queue.Queue):
+def stream_ollama(prompt: str, out_q: queue.Queue, model: str | None = None):
+    model = model or MODEL
     try:
         with requests.post(
             OLLAMA_URL,
             headers={"Content-Type": "application/json"},
             data=json.dumps({
-                "model": MODEL,
+                "model": model,
                 "prompt": prompt,
                 "options": {"temperature": TEMP},
-                "stream": True
+                "stream": True,
             }),
-            stream=True, timeout=180,
+            stream=True,
+            timeout=180,
         ) as r:
             r.raise_for_status()
             for line in r.iter_lines(decode_unicode=True):

--- a/ollama_client.py
+++ b/ollama_client.py
@@ -1,10 +1,12 @@
 import json
 import queue
+
 import requests
 
 from config import MODEL, OLLAMA_BASE_URL, TEMP
 
 OLLAMA_URL = f"{OLLAMA_BASE_URL}/generate"
+
 
 def stream_ollama(prompt: str, out_q: queue.Queue, model: str | None = None):
     model = model or MODEL
@@ -16,16 +18,16 @@ def stream_ollama(prompt: str, out_q: queue.Queue, model: str | None = None):
     print(f"[stream_ollama] requesting model={model}")
     try:
         with requests.post(
-            OLLAMA_URL,
-            headers={"Content-Type": "application/json"},
-            data=json.dumps({
-                "model": model,
-                "prompt": prompt,
-                "options": {"temperature": TEMP},
-                "stream": True,
-            }),
-            stream=True,
-            timeout=180,
+                OLLAMA_URL,
+                headers={"Content-Type": "application/json"},
+                data=json.dumps({
+                    "model": model,
+                    "prompt": prompt,
+                    "options": {"temperature": TEMP},
+                    "stream": True,
+                }),
+                stream=True,
+                timeout=180,
         ) as r:
             r.raise_for_status()
             confirmed = False

--- a/utils.py
+++ b/utils.py
@@ -1,10 +1,11 @@
 """Small utilities and static prompts."""
 
 ACTIONS = {
-    "explain": "Explain what this code does, list concrete risks, and breakdown the flow",
-    "refactor": "Refactor for readability. Follow professional best practices like SRP and Preserve behavior.",
-    "tests": "Generate focused unit tests with Arrange-Act-Assert and edge cases.",
-    "performance": "Rewrite for maximum performance gain without changing functionality",
+    "explain": "Explain what this code does, list concrete risks, and break down the flow.",
+    "refactor": "Refactor for readability. Follow professional best practices like SRP (Single Responsibility Principle) and Preserve behavior.",
+    "tests": "Generate focused unit tests with Arrange-Act-Assert structure and cover edge cases.",
+    "performance": "Rewrite for maximum performance gain without changing functionality.",
+    "simplify": "Simplify the code to make it more readable and easier to understand while preserving its original functionality."
 }
 
 

--- a/workers/chat_worker.py
+++ b/workers/chat_worker.py
@@ -12,16 +12,17 @@ class ChatWorker(QThread):
     done = Signal()
     error = Signal(str)
 
-    def __init__(self, messages: list[dict]):
+    def __init__(self, messages: list[dict], model: str | None = None):
         super().__init__()
         self.messages = messages
+        self.model = model or MODEL
 
     def run(self):
         try:
             with requests.post(
                 OLLAMA_CHAT_URL,
                 json={
-                    "model": MODEL,
+                    "model": self.model,
                     "messages": self.messages,
                     "options": {
                         "temperature": float(TEMP),

--- a/workers/chat_worker.py
+++ b/workers/chat_worker.py
@@ -1,9 +1,9 @@
-import json
-
-import requests
+import queue
+import threading
 from PySide6.QtCore import QThread, Signal
 
-from config import MODEL, TEMP, OLLAMA_CHAT_URL, NUM_CTX, KEEP_ALIVE
+from config import MODEL
+from ollama_client import stream_ollama
 
 
 class ChatWorker(QThread):
@@ -17,43 +17,39 @@ class ChatWorker(QThread):
         self.messages = messages
         self.model = model or MODEL
 
-    def run(self):
-        try:
-            with requests.post(
-                OLLAMA_CHAT_URL,
-                json={
-                    "model": self.model,
-                    "messages": self.messages,
-                    "options": {
-                        "temperature": float(TEMP),
-                        "num_ctx": int(NUM_CTX),
-                    },
-                    "keep_alive": str(KEEP_ALIVE),
-                    "stream": True,
-                },
-                stream=True,
-                timeout=(10, 600),
-            ) as r:
-                try:
-                    r.raise_for_status()
-                except requests.HTTPError:
-                    self.error.emit(f"HTTP {r.status_code}: {r.text}")
-                    return
+    def _build_prompt(self) -> str:
+        parts: list[str] = []
+        for msg in self.messages:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+            if role == "system":
+                parts.append(content)
+            else:
+                parts.append(f"{role}: {content}")
+        parts.append("assistant:")
+        return "\n".join(parts)
 
-                for line in r.iter_lines(decode_unicode=True):
-                    if not line:
-                        continue
-                    try:
-                        obj = json.loads(line)
-                        msg = obj.get("message") or {}
-                        txt = msg.get("content", "") or obj.get("response", "")
-                    except json.JSONDecodeError:
-                        txt = line
-                    if txt:
-                        self.chunk.emit(txt)
-        except requests.exceptions.RequestException as e:
-            self.error.emit(f"Network error: {e}")
+    def run(self):
+        prompt = self._build_prompt()
+        q: queue.Queue[str | None] = queue.Queue()
+
+        def worker():
+            stream_ollama(prompt, q, model=self.model)
+
+        t = threading.Thread(target=worker, daemon=True)
+        t.start()
+
+        try:
+            while True:
+                chunk = q.get()
+                if chunk is None:
+                    break
+                if chunk.startswith("[Error]") or chunk.startswith("\n[Error]"):
+                    self.error.emit(chunk.strip())
+                else:
+                    self.chunk.emit(chunk)
         except Exception as e:
             self.error.emit(str(e))
         finally:
+            t.join()
             self.done.emit()


### PR DESCRIPTION
## Summary
- allow configuring available models via MODEL_LIST env var
- add combo box to select model and persist selection
- send selected model to ChatWorker for requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b24d55b08c8321afbd4a88eb85aab1