### PR TITLE
Support general chat when no selection

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,13 +51,7 @@ def main():
         )
     if not sel and not sys.stdin.isatty():
         sel = sys.stdin.read()
-    if not sel and args.filepath and os.path.exists(args.filepath):
-        with open(args.filepath, "r", encoding="utf-8", errors="replace") as f:
-            sel = f.read()
-
-    if not sel.strip():
-        print("No selection provided.", file=sys.stderr)
-        sys.exit(1)
+    # If no selection was found, proceed with an empty string to allow general chat mode.
 
     # Try to hand off to an existing window (single-instance UX)
     if send_open_session(sel, label):

--- a/main.py
+++ b/main.py
@@ -65,17 +65,17 @@ def parse_args():
     p.add_argument("--filepath")  # absolute path
 
     # absolute offsets (accept strings; convert later to avoid argparse aborts)
-    p.add_argument("--sel-start")
-    p.add_argument("--sel-end")
+    p.add_argument("--sel-start", nargs="?")
+    p.add_argument("--sel-end", nargs="?")
 
     # line/column (1-based; accept strings; convert later)
-    p.add_argument("--sel-start-line")
-    p.add_argument("--sel-start-col")
-    p.add_argument("--sel-end-line")
-    p.add_argument("--sel-end-col")
+    p.add_argument("--sel-start-line", nargs="?")
+    p.add_argument("--sel-start-col", nargs="?")
+    p.add_argument("--sel-end-line", nargs="?")
+    p.add_argument("--sel-end-col", nargs="?")
 
     # raw selection text
-    p.add_argument("--selection")
+    p.add_argument("--selection", nargs="?")
     return p.parse_args()
 
 

--- a/main.py
+++ b/main.py
@@ -112,10 +112,6 @@ def get_selection(args) -> tuple[str, str]:
     if not sys.stdin.isatty():
         return sys.stdin.read(), title
 
-    # 5) whole file as last resort
-    if file_text:
-        return file_text, title
-
     return "", title
 
 
@@ -140,9 +136,6 @@ def send_to_running_instance(code: str, file_name: str) -> bool:
 def main():
     args = parse_args()
     code, display_name = get_selection(args)
-    if not code.strip():
-        print("No selection provided.", file=sys.stderr)
-        sys.exit(1)
 
     # If an instance is running, hand off via IPC and exit.
     if send_to_running_instance(code, display_name):

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -173,8 +173,7 @@ class MainWindow(QMainWindow):
             if msg.get("cmd") == "open_session":
                 code = msg.get("code", "")
                 file_name = msg.get("file", "selection")
-                if code.strip():
-                    self.new_tab(code, file_name, select=True)
-                    self.bring_to_front()
+                self.new_tab(code, file_name, select=True)
+                self.bring_to_front()
         finally:
             sock.disconnectFromServer()

--- a/ui/session_widget.py
+++ b/ui/session_widget.py
@@ -128,14 +128,15 @@ class SessionWidget(QWidget):
 
     # conversation plumbing
     def _build_system_message(self):
-        self.history = [{
-            "role": "system",
-            "content": (
-                "You are a senior software engineer. Be concise and precise. "
-                "Pinned code context follows.\n\n"
+        base = "You are a senior software engineer. Be concise and precise."
+        if self.code.strip():
+            content = (
+                base + " Pinned code context follows.\n\n" +
                 f"```{self.lang}\n{self.code}\n```"
-            ),
-        }]
+            )
+        else:
+            content = base
+        self.history = [{"role": "system", "content": content}]
 
     def _user_say(self, text: str):
         self.history.append({"role": "user", "content": text})
@@ -191,6 +192,8 @@ class SessionWidget(QWidget):
 
     # rendering
     def _append_code_context_block(self):
+        if not self.code.strip():
+            return
         lang = self.lang or "plaintext"
         self._html.append('<div class="role">system</div>')
         self._html.append(


### PR DESCRIPTION
## Summary
- Permit launching LocalPilot with empty selections for open-ended chat sessions
- Allow IPC requests without code to spawn a blank chat tab
- Skip pinning code context when no source text is provided

## Testing
- `python -m py_compile app.py main.py ui/main_window.py ui/session_widget.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba0ab9796083218c717277bf8c0889