### PR TITLE
Add unit tests for configuration, utilities, and streaming logic

### DIFF
--- a/ollama_client.py
+++ b/ollama_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import queue
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,41 @@
+import importlib
+import sys
+import types
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def load_app(monkeypatch):
+    sys.modules.pop("app", None)
+    pyside6 = types.ModuleType("PySide6")
+    qtwidgets = types.ModuleType("PySide6.QtWidgets")
+    qtwidgets.QApplication = type("QApplication", (), {"__init__": lambda self, *a, **k: None})
+    qtnetwork = types.ModuleType("PySide6.QtNetwork")
+    qtnetwork.QLocalSocket = type("QLocalSocket", (), {"__init__": lambda self, *a, **k: None})
+    monkeypatch.setitem(sys.modules, "PySide6", pyside6)
+    monkeypatch.setitem(sys.modules, "PySide6.QtWidgets", qtwidgets)
+    monkeypatch.setitem(sys.modules, "PySide6.QtNetwork", qtnetwork)
+
+    ipc_mod = types.ModuleType("ipc")
+    ipc_mod.send_open_session = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "ipc", ipc_mod)
+    ui_mod = types.ModuleType("ui.main_window")
+    ui_mod.SOCKET_NAME = "dummy"
+    ui_mod.MainWindow = object
+    monkeypatch.setitem(sys.modules, "ui.main_window", ui_mod)
+
+    import app
+    return importlib.reload(app)
+
+
+def test_read_selection_from_ranges(monkeypatch):
+    app = load_app(monkeypatch)
+    with tempfile.NamedTemporaryFile("w+", delete=False) as tmp:
+        tmp.write("line1\nline2\n")
+        tmp.flush()
+        text = app._read_selection_from_ranges(tmp.name, 1, 2, 2, 3)
+    assert text == "ine1\nli"

--- a/tests/test_chat_worker.py
+++ b/tests/test_chat_worker.py
@@ -1,0 +1,41 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+def load_worker(monkeypatch):
+    sys.modules.pop('workers.chat_worker', None)
+    pyside6 = types.ModuleType('PySide6')
+    qtcore = types.ModuleType('PySide6.QtCore')
+
+    class DummySignal:
+        def __init__(self, *a, **k):
+            pass
+        def connect(self, *a, **k):
+            pass
+        def emit(self, *a, **k):
+            pass
+    qtcore.QThread = object
+    qtcore.Signal = lambda *a, **k: DummySignal()
+
+    monkeypatch.setitem(sys.modules, 'PySide6', pyside6)
+    monkeypatch.setitem(sys.modules, 'PySide6.QtCore', qtcore)
+    monkeypatch.setitem(sys.modules, 'requests', types.SimpleNamespace(get=lambda *a, **k: None))
+    import workers.chat_worker as cw
+    return importlib.reload(cw)
+
+
+def test_build_prompt(monkeypatch):
+    cw = load_worker(monkeypatch)
+    messages = [
+        {'role': 'system', 'content': 'sys'},
+        {'role': 'user', 'content': 'u'},
+        {'role': 'assistant', 'content': 'a'},
+    ]
+    worker = cw.ChatWorker(messages, model='x')
+    prompt = worker._build_prompt()
+    assert 'sys' in prompt
+    assert 'user: u' in prompt
+    assert prompt.strip().endswith('assistant:')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,37 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+def load_config(monkeypatch, get_impl):
+    dummy = types.SimpleNamespace(get=get_impl)
+    monkeypatch.setitem(sys.modules, 'requests', dummy)
+    import config
+    return importlib.reload(config)
+
+
+def test_fetch_models_from_env(monkeypatch):
+    cfg = load_config(monkeypatch, lambda *a, **k: None)
+    monkeypatch.setenv('MODEL_LIST', 'a, b, ,c')
+    assert cfg._fetch_models() == ['a', 'b', 'c']
+
+
+def test_fetch_models_from_server(monkeypatch):
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+        def json(self):
+            return {'models': [{'name': 'm1'}, {'model': 'm2'}, {}]}
+    cfg = load_config(monkeypatch, lambda *a, **k: FakeResponse())
+    monkeypatch.delenv('MODEL_LIST', raising=False)
+    assert cfg._fetch_models() == ['m1', 'm2']
+
+
+def test_fetch_models_failure(monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError('fail')
+    cfg = load_config(monkeypatch, boom)
+    monkeypatch.delenv('MODEL_LIST', raising=False)
+    assert cfg._fetch_models() == []

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -1,0 +1,57 @@
+import importlib
+import sys
+import types
+import queue
+
+import pytest
+
+
+def load_client(monkeypatch, post_impl):
+    dummy = types.SimpleNamespace(post=post_impl)
+    monkeypatch.setitem(sys.modules, 'requests', dummy)
+    import ollama_client
+    return importlib.reload(ollama_client)
+
+
+class DummyResponse:
+    def __init__(self, lines):
+        self.lines = lines
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+    def iter_lines(self, decode_unicode=True):
+        for l in self.lines:
+            yield l
+    def raise_for_status(self):
+        pass
+
+
+def test_stream_success(monkeypatch):
+    def fake_post(*a, **k):
+        return DummyResponse(['{"model":"m","response":"hi"}', '{"response":" there"}'])
+    client = load_client(monkeypatch, fake_post)
+    q = queue.Queue()
+    client.stream_ollama('prompt', q, model='m')
+    assert q.get() == 'hi'
+    assert q.get() == ' there'
+    assert q.get() is None
+
+
+def test_stream_no_model(monkeypatch):
+    client = load_client(monkeypatch, lambda *a, **k: DummyResponse([]))
+    q = queue.Queue()
+    client.stream_ollama('prompt', q, model='')
+    assert q.get().startswith('\n[Error]')
+    assert q.get() is None
+
+
+def test_stream_error(monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError('fail')
+    client = load_client(monkeypatch, boom)
+    q = queue.Queue()
+    client.stream_ollama('p', q, model='x')
+    first = q.get()
+    assert first.startswith('\n[Error]')
+    assert q.get() is None

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from resources.html_template import load_html_template
+
+
+def test_load_html_template_from_filesystem(monkeypatch):
+    def boom(*a, **k):
+        raise FileNotFoundError
+    monkeypatch.setattr('resources.html_template._res.files', boom)
+    tpl = load_html_template()
+    assert '<html' in tpl.lower()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils import lang_hint, build_prompt
+
+
+def test_lang_hint_known_extensions():
+    assert lang_hint('example.py') == 'python'
+    assert lang_hint('script.JS') == 'javascript'
+    assert lang_hint('style.CSS') == 'css'
+
+
+def test_lang_hint_default_plaintext():
+    assert lang_hint('unknown.ext') == 'plaintext'
+    assert lang_hint('') == 'plaintext'
+
+
+def test_build_prompt_includes_task_code_and_lang():
+    prompt = build_prompt('Do something', 'print(1)', 'python')
+    assert 'Task:\nDo something' in prompt
+    assert '```python\nprint(1)\n```' in prompt

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 from PySide6.QtCore import Qt, QTimer, QSettings

--- a/ui/session_widget.py
+++ b/ui/session_widget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import time
 from html import escape

--- a/workers/chat_worker.py
+++ b/workers/chat_worker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import queue
 import threading
 from PySide6.QtCore import QThread, Signal


### PR DESCRIPTION
## Summary
- add pytest-based unit tests for utilities, configuration, streaming client, and chat worker prompt building
- test HTML template loading and selection extraction logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba120d2be48321a0985427fc902c23