### PR TITLE
Warm up model on open and focus

### DIFF
--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -123,7 +123,9 @@ class MainWindow(QMainWindow):
 
     def _focus_current(self):
         w = self.tabs.currentWidget()
-        if w and hasattr(w, "input"):
+        if w and hasattr(w, "focus_input"):
+            w.focus_input()
+        elif w and hasattr(w, "input"):
             w.input.setFocus(Qt.ActiveWindowFocusReason)
 
     # Tabs

--- a/ui/session_widget.py
+++ b/ui/session_widget.py
@@ -18,6 +18,7 @@ from PySide6.QtWidgets import (
 from markdown_it import MarkdownIt
 
 from config import fetch_ollama_models, MODEL
+from ollama_client import warm_up_model
 from resources.html_template import HTML_TEMPLATE
 from ui.input_widget import AutoResizingTextEdit
 from utils import ACTIONS, lang_hint
@@ -69,6 +70,7 @@ class SessionWidget(QWidget):
         top.addWidget(self.refresh_btn)
 
         self._setup_model_selector()
+        self.warm_up()
 
         # Transcript view
         self.view = QWebEngineView()
@@ -163,7 +165,13 @@ class SessionWidget(QWidget):
         self._chat()
 
     def focus_input(self):
+        self.warm_up()
         self.input.setFocus(Qt.TabFocusReason)
+
+    def warm_up(self):
+        model = self.model_combo.currentText().strip()
+        if model and model != "No Ollama Models Found":
+            warm_up_model(model)
 
     # conversation plumbing
     def _build_system_message(self):


### PR DESCRIPTION
## Summary
- Add background `warm_up_model` helper to prime the selected Ollama model
- Warm up the model when a session opens and whenever its input gains focus
- Ensure main window uses the session's focus method so model warms when the app is focused

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c03da1d5148321be297aae94f1e31d