### PR TITLE
Add Run Ollama button to start server

### DIFF
--- a/config.py
+++ b/config.py
@@ -46,6 +46,16 @@ def fetch_ollama_models() -> list[str]:
     return []
 
 
+def is_ollama_running() -> bool:
+    """Return True if the Ollama server responds, False otherwise."""
+    try:
+        r = requests.get(OLLAMA_TAGS_URL, timeout=1)
+        r.raise_for_status()
+        return True
+    except Exception:
+        return False
+
+
 MODEL_LIST = fetch_ollama_models()
 
 MODEL = MODEL_LIST[0] if MODEL_LIST else []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,3 +68,20 @@ def test_config_initial_no_model(monkeypatch):
     cfg = load_config(monkeypatch, lambda *a, **k: FakeResponse())
     assert cfg.MODEL_LIST == []
     assert cfg.MODEL == []
+
+
+def test_is_ollama_running_true(monkeypatch):
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+    cfg = load_config(monkeypatch, lambda *a, **k: FakeResponse())
+    assert cfg.is_ollama_running() is True
+
+
+def test_is_ollama_running_false(monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("fail")
+
+    cfg = load_config(monkeypatch, boom)
+    assert cfg.is_ollama_running() is False

--- a/ui/session_widget.py
+++ b/ui/session_widget.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
+import shutil
+import subprocess
 import time
 from html import escape
 
@@ -17,7 +20,7 @@ from PySide6.QtWidgets import (
 )
 from markdown_it import MarkdownIt
 
-from config import fetch_ollama_models, MODEL
+from config import fetch_ollama_models, MODEL, is_ollama_running
 from resources.html_template import HTML_TEMPLATE
 from ui.input_widget import AutoResizingTextEdit
 from utils import ACTIONS, lang_hint
@@ -64,9 +67,14 @@ class SessionWidget(QWidget):
         self.refresh_btn = self._mk_btn("Refresh", self._setup_model_selector)
         self.refresh_btn.setVisible(False)
 
+        # Run Ollama button
+        self.run_ollama_btn = self._mk_btn("Run Ollama", self._run_ollama_server)
+        self.run_ollama_btn.setVisible(False)
+
         top.addWidget(self.model_lbl)
         top.addWidget(self.model_combo)
         top.addWidget(self.refresh_btn)
+        top.addWidget(self.run_ollama_btn)
 
         self._setup_model_selector()
 
@@ -144,12 +152,42 @@ class SessionWidget(QWidget):
             self._on_model_changed(self.model_combo.currentText())
             self.status.showMessage("Ready")
             self.refresh_btn.setVisible(False)
+            self.run_ollama_btn.setVisible(False)
         else:
+            server_up = is_ollama_running()
             self.model_combo.addItem("No Ollama Models Found")
             self.model_combo.setCurrentIndex(0)
             self.model_combo.setEnabled(False)
-            self.status.showMessage("No Ollama models found. Click Refresh to check again.")
+            if server_up:
+                self.status.showMessage("No Ollama models found. Click Refresh to check again.")
+            else:
+                self.status.showMessage("Ollama server not running. Click Run Ollama to start it.")
             self.refresh_btn.setVisible(True)
+            self.run_ollama_btn.setVisible(not server_up)
+
+    def _run_ollama_server(self):
+        """Attempt to start the Ollama server with predefined settings."""
+        env = os.environ.copy()
+        env.update({
+            "OLLAMA_NUM_PARALLEL": "2",
+            "OLLAMA_MAX_LOADED_MODELS": "2",
+            "OLLAMA_FLASH_ATTENTION": "1",
+            "OLLAMA_KV_CACHE_TYPE": "q8_0",
+        })
+        cmd = shutil.which("ollama") or "/opt/homebrew/opt/ollama/bin/ollama"
+        try:
+            subprocess.Popen(
+                [cmd, "serve"],
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            self.status.showMessage("Ollama server starting…")
+            self.run_ollama_btn.setVisible(False)
+            QTimer.singleShot(2000, self._setup_model_selector)
+        except Exception as exc:
+            self.status.showMessage(f"Failed to start Ollama: {exc}")
 
     def create_button_handler(self, key):
         return lambda: self.auto_run(ACTIONS[key])


### PR DESCRIPTION
## Summary
- add `is_ollama_running` helper
- add "Run Ollama" button to session UI that starts server with predefined env vars
- test server detection logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c03d571db88321a1bf79a52066e023