### PR TITLE
Prevent freeze when stopping chat generation

### DIFF
--- a/tests/test_chat_worker.py
+++ b/tests/test_chat_worker.py
@@ -1,6 +1,8 @@
 import importlib
 import sys
 import types
+import threading
+import time
 
 import pytest
 
@@ -22,9 +24,43 @@ def load_worker(monkeypatch):
 
     monkeypatch.setitem(sys.modules, 'PySide6', pyside6)
     monkeypatch.setitem(sys.modules, 'PySide6.QtCore', qtcore)
-    monkeypatch.setitem(sys.modules, 'requests', types.SimpleNamespace(get=lambda *a, **k: None))
+    monkeypatch.setitem(sys.modules, 'requests', types.SimpleNamespace(post=lambda *a, **k: None))
     import workers.chat_worker as cw
     return importlib.reload(cw)
+
+
+def load_worker_thread(monkeypatch, stream_impl):
+    sys.modules.pop('workers.chat_worker', None)
+    pyside6 = types.ModuleType('PySide6')
+    qtcore = types.ModuleType('PySide6.QtCore')
+
+    class DummySignal:
+        def __init__(self):
+            self._cbs = []
+        def connect(self, cb):
+            self._cbs.append(cb)
+        def emit(self, *a, **k):
+            for cb in list(self._cbs):
+                cb(*a, **k)
+
+    class DummyQThread(threading.Thread):
+        def __init__(self, *a, **k):
+            super().__init__()
+        def isRunning(self):
+            return self.is_alive()
+        def wait(self, msecs=None):
+            self.join(None if msecs is None else msecs / 1000)
+
+    qtcore.QThread = DummyQThread
+    qtcore.Signal = lambda *a, **k: DummySignal()
+
+    monkeypatch.setitem(sys.modules, 'PySide6', pyside6)
+    monkeypatch.setitem(sys.modules, 'PySide6.QtCore', qtcore)
+    monkeypatch.setitem(sys.modules, 'requests', types.SimpleNamespace(post=lambda *a, **k: None))
+    import workers.chat_worker as cw
+    cw = importlib.reload(cw)
+    monkeypatch.setattr(cw, 'stream_ollama', stream_impl)
+    return cw
 
 
 def test_build_prompt(monkeypatch):
@@ -39,3 +75,21 @@ def test_build_prompt(monkeypatch):
     assert 'sys' in prompt
     assert 'user: u' in prompt
     assert prompt.strip().endswith('assistant:')
+
+
+def test_worker_stop(monkeypatch):
+    def fake_stream(prompt, out_q, model=None, stop_event=None):
+        out_q.put('hi')
+        while not (stop_event and stop_event.is_set()):
+            time.sleep(0.01)
+        out_q.put(None)
+
+    cw = load_worker_thread(monkeypatch, fake_stream)
+    worker = cw.ChatWorker([], model='x')
+    chunks = []
+    worker.chunk.connect(chunks.append)
+    worker.start()
+    time.sleep(0.05)
+    worker.stop()
+    worker.wait(500)
+    assert chunks == ['hi']

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -148,7 +148,8 @@ class MainWindow(QMainWindow):
             return
         try:
             if getattr(w, "_worker", None) and w._worker.isRunning():
-                w._worker.terminate()
+                w._worker.stop()
+                w._worker.wait()
         except Exception:
             pass
         self.tabs.removeTab(index)

--- a/ui/session_widget.py
+++ b/ui/session_widget.py
@@ -235,7 +235,8 @@ class SessionWidget(QWidget):
             return
 
         if self._worker and self._worker.isRunning():
-            self._worker.terminate()
+            self._worker.stop()
+            self._worker.wait()
 
         self._assistant_md = ""
         self._render_buf = []
@@ -330,7 +331,8 @@ class SessionWidget(QWidget):
     def _stop_generation(self):
         if self._worker and self._worker.isRunning():
             try:
-                self._worker.terminate()
+                self._worker.stop()
+                self._worker.wait()
             except Exception:
                 pass
             self._worker = None


### PR DESCRIPTION
## Summary
- Add stop-event support to `stream_ollama` and `ChatWorker`
- Replace thread termination with graceful stop in session and main window widgets
- Test worker stop to ensure generation can be halted safely

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c058c0d6548321b59321b19c97b8bc