### PR TITLE
Add AWS Bedrock model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Runtime settings in the UI include:
 - context window
 - keep-alive duration
 - local Ollama launch defaults
+- optional AWS Bedrock profile, region, and model selection
 
 Quick prompts in the UI can be:
 
@@ -117,6 +118,56 @@ For advanced environment overrides:
 
 - `OLLAMA_URL` changes the Ollama API base URL
 - `MODEL_LIST` pins the visible model list
+
+## AWS Bedrock
+
+LocalPilot can also use AWS Bedrock models in the same model dropdown as Ollama. Bedrock is optional and disabled by default.
+
+Requirements:
+
+- `boto3` installed from `requirements.txt`
+- AWS CLI installed
+- an AWS profile with Bedrock access
+- if your profile uses AWS SSO, a valid SSO login session
+
+Typical AWS setup:
+
+```bash
+export AWS_PROFILE="your-profile"
+export AWS_REGION="us-east-1"
+aws sso login --profile "$AWS_PROFILE"
+```
+
+How to enable it in LocalPilot:
+
+1. Open `Settings`.
+2. In the `AWS Bedrock` section, enable Bedrock.
+3. Choose an AWS profile.
+4. Choose an AWS region.
+5. Click `AWS SSO Login` if the selected profile uses SSO.
+6. Click `Refresh Bedrock Models`.
+
+Model selection notes:
+
+- LocalPilot now filters the Bedrock list to active, chat-capable inference profiles.
+- Prefer current inference-profile IDs such as `global.anthropic.claude-sonnet-4-6`, `us.amazon.nova-pro-v1:0`, or the `us.meta.llama4-*` profiles.
+- Old or legacy raw foundation-model IDs may appear in AWS generally, but LocalPilot should avoid offering the ones that are known to fail with `Converse`.
+- Bedrock models are tinted differently in the main model dropdown so they are easy to distinguish from Ollama models.
+
+Common Bedrock issues:
+
+- **`ForbiddenException` / `GetRoleCredentials`**  
+  Your AWS profile is not logged in or does not have Bedrock access. Run:
+
+  ```bash
+  aws sso login --profile "$AWS_PROFILE"
+  ```
+
+- **`ValidationException` saying an inference profile is required**  
+  That model needs an inference profile ID instead of a raw foundation-model ID. Refresh the Bedrock list and pick one of the Bedrock entries offered by LocalPilot.
+
+- **`ResourceNotFoundException` for legacy or end-of-life models**  
+  The selected model is no longer usable for your account or region. Refresh the Bedrock list and choose a newer profile.
 
 ## Ollama notes
 

--- a/aws_bedrock_discovery.py
+++ b/aws_bedrock_discovery.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+DEFAULT_BEDROCK_MODEL_IDS = [
+    "global.anthropic.claude-sonnet-4-6",
+    "us.amazon.nova-pro-v1:0",
+    "us.meta.llama4-scout-17b-instruct-v1:0",
+    "us.meta.llama4-maverick-17b-instruct-v1:0",
+    "us.deepseek.r1-v1:0",
+]
+
+PREFERRED_BEDROCK_REGIONS = [
+    "us-east-1",
+    "us-west-2",
+    "us-east-2",
+    "us-west-1",
+    "eu-west-1",
+    "eu-west-2",
+    "eu-central-1",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class BedrockModelDiscoveryResult:
+    model_ids: list[str]
+    status_message: str
+    requires_login: bool = False
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        cleaned = value.strip()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        deduped.append(cleaned)
+    return deduped
+
+
+def available_aws_profiles() -> list[str]:
+    profiles: list[str] = []
+    aws_cli = shutil.which("aws")
+    if aws_cli is not None:
+        try:
+            completed = subprocess.run(
+                [aws_cli, "configure", "list-profiles"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            if completed.returncode == 0:
+                profiles.extend(completed.stdout.splitlines())
+        except (OSError, subprocess.SubprocessError):
+            pass
+    if not profiles:
+        try:
+            import boto3
+
+            profiles.extend(boto3.Session().available_profiles)
+        except Exception:
+            pass
+    return _dedupe(profiles)
+
+
+def available_bedrock_regions() -> list[str]:
+    regions: list[str] = []
+    try:
+        import boto3
+
+        regions = boto3.session.Session().get_available_regions("bedrock-runtime")
+    except Exception:
+        pass
+    return _dedupe([*PREFERRED_BEDROCK_REGIONS, *regions])
+
+
+def _format_aws_cli_error(profile: str, region: str, stderr: str, stdout: str) -> tuple[str, bool]:
+    text = (stderr or stdout or "").strip()
+    selected_profile = profile.strip() or "default"
+    selected_region = region.strip() or "us-east-1"
+    lowered = text.lower()
+    if "getrolecredentials" in lowered or "forbiddenexception" in lowered or "sso" in lowered:
+        return (
+            f"AWS profile '{selected_profile}' is not logged in or lacks access. "
+            f"Run `aws sso login --profile {selected_profile}` and verify Bedrock access in {selected_region}.",
+            True,
+        )
+    if text:
+        return (text, False)
+    return ("AWS CLI could not list Bedrock models.", False)
+
+
+def _foundation_model_id_from_arn(model_arn: str) -> str:
+    marker = "foundation-model/"
+    if marker not in model_arn:
+        return ""
+    return model_arn.split(marker, 1)[1].strip()
+
+
+def _is_chat_model_summary(summary: dict) -> bool:
+    model_id = str(summary.get("modelId") or "").strip().lower()
+    model_name = str(summary.get("modelName") or "").strip().lower()
+    lifecycle = summary.get("modelLifecycle") or {}
+    lifecycle_status = str(lifecycle.get("status") or "").upper()
+    input_modalities = {str(value).upper() for value in summary.get("inputModalities", [])}
+    output_modalities = {str(value).upper() for value in summary.get("outputModalities", [])}
+    blocked_keywords = {
+        "embed",
+        "rerank",
+        "upscale",
+        "inpaint",
+        "outpaint",
+        "erase",
+        "remove-background",
+        "search-replace",
+        "search-recolor",
+        "style-transfer",
+        "style-guide",
+        "control-sketch",
+        "control-structure",
+    }
+    if lifecycle_status != "ACTIVE":
+        return False
+    if "TEXT" not in input_modalities or "TEXT" not in output_modalities:
+        return False
+    return not any(keyword in model_id or keyword in model_name for keyword in blocked_keywords)
+
+
+def _foundation_model_summaries(profile: str, profile_args: list[str], region: str, aws_cli: str) -> tuple[dict[str, dict], str]:
+    command = [
+        aws_cli,
+        "bedrock",
+        "list-foundation-models",
+        "--by-output-modality",
+        "TEXT",
+        "--region",
+        region.strip(),
+        "--output",
+        "json",
+        "--no-cli-pager",
+    ]
+    command.extend(profile_args)
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+        if completed.returncode != 0:
+            message, _login_required = _format_aws_cli_error(profile, region, completed.stderr, completed.stdout)
+            return {}, message
+        payload = json.loads(completed.stdout) if completed.stdout.strip() else {}
+        summaries = payload.get("modelSummaries", [])
+        lookup: dict[str, dict] = {}
+        if isinstance(summaries, list):
+            for summary in summaries:
+                if not isinstance(summary, dict):
+                    continue
+                model_id = str(summary.get("modelId") or "").strip()
+                if model_id:
+                    lookup[model_id] = summary
+        return lookup, ""
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
+        return {}, "Failed to query Bedrock foundation models from AWS CLI."
+
+
+def discover_bedrock_model_ids(profile: str, region: str) -> BedrockModelDiscoveryResult:
+    model_ids: list[str] = []
+    status_messages: list[str] = []
+    requires_login = False
+    aws_cli = shutil.which("aws")
+    if aws_cli is None:
+        return BedrockModelDiscoveryResult(
+            model_ids=list(DEFAULT_BEDROCK_MODEL_IDS),
+            status_message="AWS CLI was not found. Showing starter Bedrock models only.",
+            requires_login=False,
+        )
+    if not region.strip():
+        return BedrockModelDiscoveryResult(
+            model_ids=list(DEFAULT_BEDROCK_MODEL_IDS),
+            status_message="Choose an AWS region to load Bedrock models.",
+            requires_login=False,
+        )
+    if aws_cli is not None and region.strip():
+        profile_args = []
+        if profile.strip() and profile.strip() != "default":
+            profile_args = ["--profile", profile.strip()]
+        foundation_lookup, foundation_error = _foundation_model_summaries(profile, profile_args, region, aws_cli)
+        if foundation_error:
+            status_messages.append(foundation_error)
+        command = [
+            aws_cli,
+            "bedrock",
+            "list-inference-profiles",
+            "--region",
+            region.strip(),
+            "--output",
+            "json",
+            "--no-cli-pager",
+        ]
+        command.extend(profile_args)
+        try:
+            completed = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=20,
+                check=False,
+            )
+            if completed.returncode == 0 and completed.stdout.strip():
+                payload = json.loads(completed.stdout)
+                summaries = payload.get("inferenceProfileSummaries", [])
+                if isinstance(summaries, list):
+                    for summary in summaries:
+                        if not isinstance(summary, dict):
+                            continue
+                        profile_id = summary.get("inferenceProfileId")
+                        status = str(summary.get("status") or "").upper()
+                        models = summary.get("models", [])
+                        foundation_ids = [
+                            _foundation_model_id_from_arn(str(model.get("modelArn") or ""))
+                            for model in models
+                            if isinstance(model, dict)
+                        ]
+                        foundation_summaries = [
+                            foundation_lookup[foundation_id]
+                            for foundation_id in foundation_ids
+                            if foundation_id in foundation_lookup
+                        ]
+                        is_chat_profile = any(_is_chat_model_summary(item) for item in foundation_summaries)
+                        if isinstance(profile_id, str) and profile_id and status in {"ACTIVE", ""} and is_chat_profile:
+                            model_ids.append(profile_id)
+            elif completed.returncode != 0:
+                message, login_required = _format_aws_cli_error(profile, region, completed.stderr, completed.stdout)
+                status_messages.append(message)
+                requires_login = requires_login or login_required
+        except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
+            status_messages.append("Failed to query Bedrock inference profiles from AWS CLI.")
+    return BedrockModelDiscoveryResult(
+        model_ids=_dedupe([*model_ids, *DEFAULT_BEDROCK_MODEL_IDS]),
+        status_message=status_messages[0] if status_messages else (
+            f"Loaded chat-capable Bedrock inference profiles for {(profile.strip() or 'default')} in {region.strip()}."
+        ),
+        requires_login=requires_login,
+    )
+
+
+def available_bedrock_model_ids(profile: str, region: str) -> list[str]:
+    return discover_bedrock_model_ids(profile, region).model_ids
+
+
+def login_aws_profile(profile: str, region: str) -> tuple[bool, str]:
+    aws_cli = shutil.which("aws")
+    selected_profile = profile.strip() or "default"
+    selected_region = region.strip() or "us-east-1"
+    if aws_cli is None:
+        return False, "AWS CLI was not found."
+
+    command = [aws_cli, "sso", "login", "--profile", selected_profile]
+    env = None
+    if selected_region:
+        env = {
+            **os.environ,
+            "AWS_REGION": selected_region,
+            "AWS_DEFAULT_REGION": selected_region,
+        }
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            check=False,
+            env=env,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return False, str(exc)
+    if completed.returncode != 0:
+        message, _requires_login = _format_aws_cli_error(profile, region, completed.stderr, completed.stdout)
+        return False, message
+    return True, f"AWS SSO login completed for {selected_profile}."

--- a/bedrock_client.py
+++ b/bedrock_client.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import queue
+import threading
+from typing import Any
+
+from ollama_client import build_title_messages, normalize_chat_title
+from settings_store import RuntimeSettings, SettingsStore
+
+
+class BedrockClientError(RuntimeError):
+    pass
+
+
+def _bedrock_session(profile: str, region: str):
+    try:
+        import boto3
+    except ModuleNotFoundError as exc:
+        raise BedrockClientError(
+            "AWS Bedrock support requires boto3. Install dependencies with `pip install -r requirements.txt`."
+        ) from exc
+
+    kwargs: dict[str, str] = {}
+    if profile:
+        kwargs["profile_name"] = profile
+    if region:
+        kwargs["region_name"] = region
+    return boto3.Session(**kwargs)
+
+
+def _split_system_messages(messages: list[dict[str, str]]) -> tuple[list[dict[str, str]], list[dict[str, Any]]]:
+    system_text: list[str] = []
+    converse_messages: list[dict[str, Any]] = []
+    for message in messages:
+        role = message.get("role", "user")
+        content = (message.get("content") or "").strip()
+        if not content:
+            continue
+        if role == "system":
+            system_text.append(content)
+            continue
+        converse_role = "assistant" if role == "assistant" else "user"
+        converse_messages.append(
+            {
+                "role": converse_role,
+                "content": [{"text": content}],
+            }
+        )
+    system = [{"text": "\n\n".join(system_text)}] if system_text else []
+    return converse_messages, system
+
+
+def _format_bedrock_exception(exc: Exception, runtime: RuntimeSettings) -> str:
+    message = str(exc).strip() or exc.__class__.__name__
+    lowered = message.lower()
+    profile = runtime.bedrock_aws_profile or "default"
+    region = runtime.bedrock_aws_region or "us-east-1"
+    if "getrolecredentials" in lowered or "forbiddenexception" in lowered or "sso" in lowered:
+        return (
+            f"AWS profile '{profile}' is not logged in or lacks Bedrock access in {region}. "
+            f"Run `aws sso login --profile {profile}` and verify the profile can use Bedrock."
+        )
+    return message
+
+
+def _bedrock_inference_config(runtime: RuntimeSettings, *, max_tokens: int | None = None) -> dict[str, Any]:
+    return {
+        "maxTokens": runtime.bedrock_max_tokens if max_tokens is None else max_tokens,
+    }
+
+
+def converse_bedrock_raw(
+        messages: list[dict[str, str]],
+        *,
+        model_id: str,
+        runtime: RuntimeSettings | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+) -> dict[str, Any]:
+    runtime = runtime or SettingsStore().get_runtime_settings()
+    if not model_id:
+        raise BedrockClientError("No Bedrock model specified")
+    converse_messages, system = _split_system_messages(messages)
+    if not converse_messages:
+        raise BedrockClientError("No messages to send to Bedrock")
+
+    session = _bedrock_session(runtime.bedrock_aws_profile, runtime.bedrock_aws_region)
+    client = session.client("bedrock-runtime", region_name=runtime.bedrock_aws_region)
+    payload: dict[str, Any] = {
+        "modelId": model_id,
+        "messages": converse_messages,
+        "inferenceConfig": _bedrock_inference_config(runtime, max_tokens=max_tokens),
+    }
+    if system:
+        payload["system"] = system
+    return client.converse(**payload)
+
+
+def extract_converse_text(raw_response: dict[str, Any]) -> str:
+    content = raw_response.get("output", {}).get("message", {}).get("content", [])
+    text_parts = [item.get("text", "") for item in content if isinstance(item, dict)]
+    response_text = "\n".join(part for part in text_parts if part).strip()
+    if not response_text:
+        raise BedrockClientError("Bedrock response did not contain text output")
+    return response_text
+
+
+def stream_bedrock(
+        messages: list[dict[str, str]],
+        out_q: queue.Queue,
+        model_id: str,
+        stop_event: threading.Event | None = None,
+) -> None:
+    runtime = SettingsStore().get_runtime_settings()
+    if stop_event and stop_event.is_set():
+        out_q.put(None)
+        return
+    try:
+        response_text = extract_converse_text(
+            converse_bedrock_raw(messages, model_id=model_id, runtime=runtime)
+        )
+        if not (stop_event and stop_event.is_set()):
+            out_q.put(response_text)
+    except Exception as exc:
+        out_q.put(f"\n[Error] {_format_bedrock_exception(exc, runtime)}\n")
+    finally:
+        out_q.put(None)
+
+
+def generate_bedrock_chat_title(
+        messages: list[dict[str, str]],
+        *,
+        model_id: str,
+        file_name: str = "",
+        file_path: str = "",
+) -> str:
+    title_messages = build_title_messages(messages, file_name=file_name, file_path=file_path)
+    if not model_id or not title_messages:
+        return ""
+    runtime = SettingsStore().get_runtime_settings()
+    try:
+        response_text = extract_converse_text(
+            converse_bedrock_raw(
+                title_messages,
+                model_id=model_id,
+                runtime=runtime,
+                max_tokens=min(runtime.bedrock_max_tokens, 256),
+            )
+        )
+    except Exception:
+        return ""
+    return normalize_chat_title(response_text)

--- a/model_provider.py
+++ b/model_provider.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import queue
+import threading
+
+from bedrock_client import generate_bedrock_chat_title, stream_bedrock
+from config import MODEL
+from ollama_client import generate_chat_title, stream_ollama, warm_up_model
+from settings_store import RuntimeSettings
+
+BEDROCK_PREFIX = "bedrock:"
+BEDROCK_LABEL_PREFIX = "Bedrock: "
+
+
+def bedrock_model_key(model_id: str) -> str:
+    return f"{BEDROCK_PREFIX}{model_id.strip()}"
+
+
+def is_bedrock_model(model: str) -> bool:
+    return (model or "").strip().startswith(BEDROCK_PREFIX)
+
+
+def provider_model_id(model: str) -> str:
+    cleaned = (model or "").strip()
+    if is_bedrock_model(cleaned):
+        return cleaned[len(BEDROCK_PREFIX):].strip()
+    return cleaned
+
+
+def display_model_name(model: str) -> str:
+    if is_bedrock_model(model):
+        return f"{BEDROCK_LABEL_PREFIX}{provider_model_id(model)}"
+    return model
+
+
+def available_bedrock_models(runtime: RuntimeSettings) -> list[str]:
+    if not runtime.bedrock_enabled:
+        return []
+    return [bedrock_model_key(model_id) for model_id in runtime.bedrock_model_ids if model_id.strip()]
+
+
+def stream_model(
+        messages: list[dict[str, str]],
+        out_q: queue.Queue,
+        *,
+        model: str | None = None,
+        stop_event: threading.Event | None = None,
+) -> None:
+    selected = MODEL if model is None else (model or "").strip()
+    if is_bedrock_model(selected):
+        stream_bedrock(messages, out_q, model_id=provider_model_id(selected), stop_event=stop_event)
+        return
+    stream_ollama(messages, out_q, model=selected, stop_event=stop_event)
+
+
+def generate_model_chat_title(
+        messages: list[dict[str, str]],
+        *,
+        model: str | None = None,
+        file_name: str = "",
+        file_path: str = "",
+) -> str:
+    selected = MODEL if model is None else (model or "").strip()
+    if is_bedrock_model(selected):
+        return generate_bedrock_chat_title(
+            messages,
+            model_id=provider_model_id(selected),
+            file_name=file_name,
+            file_path=file_path,
+        )
+    return generate_chat_title(
+        messages,
+        model=selected,
+        file_name=file_name,
+        file_path=file_path,
+    )
+
+
+def warm_up_selected_model(model: str | None = None) -> None:
+    selected = MODEL if model is None else (model or "").strip()
+    if not selected or is_bedrock_model(selected):
+        return
+    warm_up_model(selected)

--- a/ollama_client.py
+++ b/ollama_client.py
@@ -83,7 +83,6 @@ def build_title_messages(
         "- 2 to 4 words.\n"
         "- Plain text only.\n"
         "- Give just enough context to recognize the topic.\n"
-        "- No quotes, markdown, prefixes, trailing punctuation, or filler words like chat/conversation/help.\n"
         f"- Source context: {source}."
     )
     return [{"role": "system", "content": prompt}, *context]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+boto3>=1.34,<2

--- a/requirments.txt
+++ b/requirments.txt
@@ -1,1 +1,0 @@
-requests

--- a/run_localpilot.sh
+++ b/run_localpilot.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+PROJECT_DIR="/Users/ajamal/Documents/PythonProjects/localPilot"
+PYTHON_BIN="/Users/ajamal/.pyenv/versions/3.13.0/bin/python3"
+LOG_DIR="${HOME}/.localpilot"
+LOG_FILE="${LOG_DIR}/localpilot.log"
+
+mkdir -p "${LOG_DIR}"
+cd "${PROJECT_DIR}"
+
+exec "${PYTHON_BIN}" main.py >>"${LOG_FILE}" 2>&1

--- a/settings_store.py
+++ b/settings_store.py
@@ -25,6 +25,14 @@ DEFAULT_SERVE_NUM_PARALLEL = 2
 DEFAULT_SERVE_MAX_LOADED_MODELS = 2
 DEFAULT_SERVE_FLASH_ATTENTION = True
 DEFAULT_SERVE_KV_CACHE_TYPE = "q8_0"
+DEFAULT_BEDROCK_MODEL_IDS = [
+    "global.anthropic.claude-sonnet-4-6",
+    "us.amazon.nova-pro-v1:0",
+    "us.meta.llama4-maverick-17b-instruct-v1:0",
+    "us.meta.llama4-scout-17b-instruct-v1:0",
+    "us.deepseek.r1-v1:0",
+]
+DEFAULT_BEDROCK_MAX_TOKENS = 4096
 
 DEFAULT_QUICK_PROMPTS: "OrderedDict[str, str]" = OrderedDict(
     [
@@ -49,6 +57,11 @@ class RuntimeSettings:
     serve_max_loaded_models: int
     serve_flash_attention: bool
     serve_kv_cache_type: str
+    bedrock_enabled: bool
+    bedrock_aws_profile: str
+    bedrock_aws_region: str
+    bedrock_model_ids: tuple[str, ...]
+    bedrock_max_tokens: int
 
     @property
     def ollama_chat_url(self) -> str:
@@ -86,6 +99,15 @@ def default_runtime_settings() -> RuntimeSettings:
         serve_max_loaded_models=DEFAULT_SERVE_MAX_LOADED_MODELS,
         serve_flash_attention=DEFAULT_SERVE_FLASH_ATTENTION,
         serve_kv_cache_type=DEFAULT_SERVE_KV_CACHE_TYPE,
+        bedrock_enabled=False,
+        bedrock_aws_profile=os.environ.get("AWS_PROFILE", "").strip(),
+        bedrock_aws_region=(
+            os.environ.get("AWS_REGION")
+            or os.environ.get("AWS_DEFAULT_REGION")
+            or "us-east-1"
+        ).strip(),
+        bedrock_model_ids=tuple(DEFAULT_BEDROCK_MODEL_IDS),
+        bedrock_max_tokens=DEFAULT_BEDROCK_MAX_TOKENS,
     )
 
 
@@ -126,6 +148,22 @@ def normalize_ollama_base_url(raw: str) -> str:
     if not value.endswith("/api"):
         value = f"{value}/api"
     return value
+
+
+def normalize_bedrock_model_ids(raw: str | list[str] | tuple[str, ...]) -> tuple[str, ...]:
+    if isinstance(raw, str):
+        candidates = raw.replace(",", "\n").splitlines()
+    else:
+        candidates = [str(item) for item in raw]
+    models: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        model_id = candidate.strip()
+        if not model_id or model_id in seen:
+            continue
+        seen.add(model_id)
+        models.append(model_id)
+    return tuple(models)
 
 
 def normalize_quick_prompts(prompts: list[dict[str, str]] | list[tuple[str, str]]) -> list[dict[str, str]]:
@@ -192,6 +230,32 @@ class SettingsStore:
                 self.settings.value("runtime/serve_kv_cache_type", defaults.serve_kv_cache_type, type=str)
                 or defaults.serve_kv_cache_type
             ).strip(),
+            bedrock_enabled=_coerce_bool(
+                self.settings.value("runtime/bedrock_enabled", defaults.bedrock_enabled),
+                defaults.bedrock_enabled,
+            ),
+            bedrock_aws_profile=(
+                self.settings.value("runtime/bedrock_aws_profile", defaults.bedrock_aws_profile, type=str)
+                or defaults.bedrock_aws_profile
+            ).strip(),
+            bedrock_aws_region=(
+                self.settings.value("runtime/bedrock_aws_region", defaults.bedrock_aws_region, type=str)
+                or defaults.bedrock_aws_region
+            ).strip(),
+            bedrock_model_ids=normalize_bedrock_model_ids(
+                self.settings.value(
+                    "runtime/bedrock_model_ids",
+                    "\n".join(defaults.bedrock_model_ids),
+                    type=str,
+                )
+            ) or defaults.bedrock_model_ids,
+            bedrock_max_tokens=max(
+                1,
+                _coerce_int(
+                    self.settings.value("runtime/bedrock_max_tokens", defaults.bedrock_max_tokens),
+                    defaults.bedrock_max_tokens,
+                ),
+            ),
         )
 
     def save_runtime_settings(self, runtime: RuntimeSettings) -> None:
@@ -204,6 +268,11 @@ class SettingsStore:
         self.settings.setValue("runtime/serve_max_loaded_models", runtime.serve_max_loaded_models)
         self.settings.setValue("runtime/serve_flash_attention", runtime.serve_flash_attention)
         self.settings.setValue("runtime/serve_kv_cache_type", runtime.serve_kv_cache_type)
+        self.settings.setValue("runtime/bedrock_enabled", bool(runtime.bedrock_enabled))
+        self.settings.setValue("runtime/bedrock_aws_profile", runtime.bedrock_aws_profile)
+        self.settings.setValue("runtime/bedrock_aws_region", runtime.bedrock_aws_region)
+        self.settings.setValue("runtime/bedrock_model_ids", "\n".join(runtime.bedrock_model_ids))
+        self.settings.setValue("runtime/bedrock_max_tokens", int(runtime.bedrock_max_tokens))
 
     def get_quick_prompts(self) -> OrderedDict[str, str]:
         raw = self.settings.value(QUICK_PROMPTS_ITEMS_KEY, "", type=str)

--- a/tests/test_aws_bedrock_discovery.py
+++ b/tests/test_aws_bedrock_discovery.py
@@ -1,0 +1,164 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import aws_bedrock_discovery as discovery
+
+
+def test_available_aws_profiles_uses_aws_cli(monkeypatch):
+    monkeypatch.setattr(discovery.shutil, "which", lambda name: "/usr/bin/aws")
+
+    def fake_run(*_args, **_kwargs):
+        return subprocess.CompletedProcess([], 0, stdout="dev\ndefault\ndev\n", stderr="")
+
+    monkeypatch.setattr(discovery.subprocess, "run", fake_run)
+    assert discovery.available_aws_profiles() == ["dev", "default"]
+
+
+def test_available_bedrock_model_ids_lists_inference_profiles(monkeypatch):
+    monkeypatch.setattr(discovery.shutil, "which", lambda name: "/usr/bin/aws")
+    seen = []
+
+    def fake_run(command, **_kwargs):
+        seen.append(command)
+        if "list-inference-profiles" in command:
+            payload = {
+                "inferenceProfileSummaries": [
+                    {
+                        "inferenceProfileId": "profile-a",
+                        "status": "ACTIVE",
+                        "models": [{"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/foundation-a"}],
+                    },
+                    {
+                        "inferenceProfileId": "profile-b",
+                        "status": "INACTIVE",
+                        "models": [{"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/foundation-b"}],
+                    },
+                ]
+            }
+        else:
+            payload = {
+                "modelSummaries": [
+                    {
+                        "modelId": "foundation-a",
+                        "modelName": "Foundation A",
+                        "inputModalities": ["TEXT"],
+                        "outputModalities": ["TEXT"],
+                        "modelLifecycle": {"status": "ACTIVE"},
+                    },
+                    {
+                        "modelId": "foundation-b",
+                        "modelName": "Foundation B",
+                        "inputModalities": ["TEXT"],
+                        "outputModalities": ["TEXT"],
+                        "modelLifecycle": {"status": "ACTIVE"},
+                    },
+                ]
+            }
+        return subprocess.CompletedProcess(command, 0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr(discovery.subprocess, "run", fake_run)
+    models = discovery.available_bedrock_model_ids("dev", "us-east-1")
+    assert models[0] == "profile-a"
+    assert "profile-b" not in models
+    assert "global.anthropic.claude-sonnet-4-6" in models
+    assert any("--profile" in command for command in seen)
+    assert any("list-foundation-models" in command for command in seen)
+
+
+def test_available_bedrock_model_ids_falls_back_to_defaults(monkeypatch):
+    monkeypatch.setattr(discovery.shutil, "which", lambda name: None)
+    assert discovery.available_bedrock_model_ids("", "us-east-1") == discovery.DEFAULT_BEDROCK_MODEL_IDS
+
+
+def test_discover_bedrock_model_ids_filters_non_chat_and_legacy_profiles(monkeypatch):
+    monkeypatch.setattr(discovery.shutil, "which", lambda name: "/usr/bin/aws")
+
+    def fake_run(command, **_kwargs):
+        if "list-foundation-models" in command:
+            payload = {
+                "modelSummaries": [
+                    {
+                        "modelId": "anthropic.good",
+                        "modelName": "Claude Good",
+                        "inputModalities": ["TEXT"],
+                        "outputModalities": ["TEXT"],
+                        "modelLifecycle": {"status": "ACTIVE"},
+                    },
+                    {
+                        "modelId": "cohere.embed-v4:0",
+                        "modelName": "Embed v4",
+                        "inputModalities": ["TEXT"],
+                        "outputModalities": ["TEXT"],
+                        "modelLifecycle": {"status": "ACTIVE"},
+                    },
+                    {
+                        "modelId": "anthropic.legacy",
+                        "modelName": "Legacy Claude",
+                        "inputModalities": ["TEXT"],
+                        "outputModalities": ["TEXT"],
+                        "modelLifecycle": {"status": "LEGACY"},
+                    },
+                ]
+            }
+        else:
+            payload = {
+                "inferenceProfileSummaries": [
+                    {
+                        "inferenceProfileId": "profile-good",
+                        "status": "ACTIVE",
+                        "models": [{"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.good"}],
+                    },
+                    {
+                        "inferenceProfileId": "profile-embed",
+                        "status": "ACTIVE",
+                        "models": [{"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/cohere.embed-v4:0"}],
+                    },
+                    {
+                        "inferenceProfileId": "profile-legacy",
+                        "status": "ACTIVE",
+                        "models": [{"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.legacy"}],
+                    },
+                ]
+            }
+        return subprocess.CompletedProcess(command, 0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr(discovery.subprocess, "run", fake_run)
+    result = discovery.discover_bedrock_model_ids("dev", "us-east-1")
+    assert "profile-good" in result.model_ids
+    assert "profile-embed" not in result.model_ids
+    assert "profile-legacy" not in result.model_ids
+
+
+def test_discover_bedrock_model_ids_reports_login_requirement(monkeypatch):
+    monkeypatch.setattr(discovery.shutil, "which", lambda name: "/usr/bin/aws")
+
+    def fake_run(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            254,
+            stdout="",
+            stderr="An error occurred (ForbiddenException) when calling the GetRoleCredentials operation: No access",
+        )
+
+    monkeypatch.setattr(discovery.subprocess, "run", fake_run)
+    result = discovery.discover_bedrock_model_ids("dev", "us-east-1")
+    assert result.requires_login is True
+    assert "aws sso login --profile dev" in result.status_message
+    assert result.model_ids == discovery.DEFAULT_BEDROCK_MODEL_IDS
+
+
+def test_login_aws_profile_reports_success(monkeypatch):
+    monkeypatch.setattr(discovery.shutil, "which", lambda name: "/usr/bin/aws")
+
+    def fake_run(command, **kwargs):
+        assert kwargs["env"]["AWS_REGION"] == "us-west-2"
+        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(discovery.subprocess, "run", fake_run)
+    success, message = discovery.login_aws_profile("dev", "us-west-2")
+    assert success is True
+    assert "AWS SSO login completed" in message

--- a/tests/test_bedrock_client.py
+++ b/tests/test_bedrock_client.py
@@ -1,0 +1,136 @@
+import importlib
+import queue
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def load_bedrock_client(monkeypatch):
+    sys.modules.pop("bedrock_client", None)
+    sys.modules.pop("ollama_client", None)
+    settings_mod = types.ModuleType("settings_store")
+    settings_mod.RuntimeSettings = object
+    settings_mod.SettingsStore = lambda: types.SimpleNamespace(
+        get_runtime_settings=lambda: types.SimpleNamespace(
+            bedrock_aws_profile="dev",
+            bedrock_aws_region="us-east-1",
+            temperature=0.2,
+            bedrock_max_tokens=4096,
+            ollama_chat_url="http://localhost:11434/api/chat",
+            keep_alive="10m",
+            num_ctx=16384,
+        )
+    )
+    monkeypatch.setitem(sys.modules, "settings_store", settings_mod)
+    import bedrock_client
+    return importlib.reload(bedrock_client)
+
+
+def test_converse_bedrock_raw_builds_payload(monkeypatch):
+    seen = {}
+
+    class FakeClient:
+        def converse(self, **payload):
+            seen["payload"] = payload
+            return {"output": {"message": {"content": [{"text": "hi"}]}}}
+
+    class FakeSession:
+        def __init__(self, **kwargs):
+            seen["session"] = kwargs
+
+        def client(self, service, region_name=None):
+            seen["client"] = (service, region_name)
+            return FakeClient()
+
+    monkeypatch.setitem(sys.modules, "boto3", types.SimpleNamespace(Session=FakeSession))
+    client = load_bedrock_client(monkeypatch)
+    runtime = types.SimpleNamespace(
+        bedrock_aws_profile="dev",
+        bedrock_aws_region="us-west-2",
+        temperature=0.4,
+        bedrock_max_tokens=1234,
+    )
+
+    raw = client.converse_bedrock_raw(
+        [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "there"},
+        ],
+        model_id="model-a",
+        runtime=runtime,
+    )
+
+    assert raw["output"]["message"]["content"][0]["text"] == "hi"
+    assert seen["session"] == {"profile_name": "dev", "region_name": "us-west-2"}
+    assert seen["client"] == ("bedrock-runtime", "us-west-2")
+    assert seen["payload"]["modelId"] == "model-a"
+    assert seen["payload"]["system"] == [{"text": "sys"}]
+    assert seen["payload"]["messages"][0] == {"role": "user", "content": [{"text": "hello"}]}
+    assert seen["payload"]["messages"][1] == {"role": "assistant", "content": [{"text": "there"}]}
+    assert seen["payload"]["inferenceConfig"] == {"maxTokens": 1234}
+
+
+def test_stream_bedrock_emits_text_and_done(monkeypatch):
+    client = load_bedrock_client(monkeypatch)
+    monkeypatch.setattr(
+        client,
+        "converse_bedrock_raw",
+        lambda *a, **k: {"output": {"message": {"content": [{"text": "answer"}]}}},
+    )
+    q = queue.Queue()
+    client.stream_bedrock([{"role": "user", "content": "hello"}], q, "model-a")
+    assert q.get() == "answer"
+    assert q.get() is None
+
+
+def test_stream_bedrock_emits_error_and_done(monkeypatch):
+    client = load_bedrock_client(monkeypatch)
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("no credentials")
+
+    monkeypatch.setattr(client, "converse_bedrock_raw", boom)
+    q = queue.Queue()
+    client.stream_bedrock([{"role": "user", "content": "hello"}], q, "model-a")
+    assert q.get().startswith("\n[Error]")
+    assert q.get() is None
+
+
+def test_missing_boto3_error_is_actionable(monkeypatch):
+    client = load_bedrock_client(monkeypatch)
+    monkeypatch.delitem(sys.modules, "boto3", raising=False)
+
+    class MissingBoto3Finder:
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname == "boto3":
+                raise ModuleNotFoundError("No module named 'boto3'")
+            return None
+
+    sys.meta_path.insert(0, MissingBoto3Finder())
+    try:
+        try:
+            client._bedrock_session("", "us-east-1")
+        except client.BedrockClientError as exc:
+            assert "pip install -r requirements.txt" in str(exc)
+        else:
+            raise AssertionError("Expected BedrockClientError")
+    finally:
+        sys.meta_path.pop(0)
+
+
+def test_stream_bedrock_rewrites_sso_forbidden_error(monkeypatch):
+    client = load_bedrock_client(monkeypatch)
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError(
+            "An error occurred (ForbiddenException) when calling the GetRoleCredentials operation: No access"
+        )
+
+    monkeypatch.setattr(client, "converse_bedrock_raw", boom)
+    q = queue.Queue()
+    client.stream_bedrock([{"role": "user", "content": "hello"}], q, "model-a")
+    assert "aws sso login --profile dev" in q.get()
+    assert q.get() is None

--- a/tests/test_chat_worker.py
+++ b/tests/test_chat_worker.py
@@ -26,6 +26,7 @@ def load_worker(monkeypatch):
     monkeypatch.setitem(sys.modules, 'PySide6.QtCore', qtcore)
     monkeypatch.setitem(sys.modules, 'requests', types.SimpleNamespace(post=lambda *a, **k: None))
     settings_mod = types.ModuleType('settings_store')
+    settings_mod.RuntimeSettings = object
     settings_mod.SettingsStore = lambda: types.SimpleNamespace(
         get_runtime_settings=lambda: types.SimpleNamespace(
             ollama_chat_url='http://localhost:11434/api/chat',
@@ -68,6 +69,7 @@ def load_worker_thread(monkeypatch, stream_impl):
     monkeypatch.setitem(sys.modules, 'PySide6.QtCore', qtcore)
     monkeypatch.setitem(sys.modules, 'requests', types.SimpleNamespace(post=lambda *a, **k: None))
     settings_mod = types.ModuleType('settings_store')
+    settings_mod.RuntimeSettings = object
     settings_mod.SettingsStore = lambda: types.SimpleNamespace(
         get_runtime_settings=lambda: types.SimpleNamespace(
             ollama_chat_url='http://localhost:11434/api/chat',
@@ -79,7 +81,7 @@ def load_worker_thread(monkeypatch, stream_impl):
     monkeypatch.setitem(sys.modules, 'settings_store', settings_mod)
     import workers.chat_worker as cw
     cw = importlib.reload(cw)
-    monkeypatch.setattr(cw, 'stream_ollama', stream_impl)
+    monkeypatch.setattr(cw, 'stream_model', stream_impl)
     return cw
 
 

--- a/tests/test_model_provider.py
+++ b/tests/test_model_provider.py
@@ -1,0 +1,64 @@
+import importlib
+import queue
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def load_model_provider(monkeypatch):
+    sys.modules.pop("model_provider", None)
+    bedrock_mod = types.ModuleType("bedrock_client")
+    bedrock_mod.stream_bedrock = lambda *a, **k: None
+    bedrock_mod.generate_bedrock_chat_title = lambda *a, **k: ""
+    ollama_mod = types.ModuleType("ollama_client")
+    ollama_mod.stream_ollama = lambda *a, **k: None
+    ollama_mod.generate_chat_title = lambda *a, **k: ""
+    ollama_mod.warm_up_model = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "bedrock_client", bedrock_mod)
+    monkeypatch.setitem(sys.modules, "ollama_client", ollama_mod)
+    import model_provider
+    return importlib.reload(model_provider)
+
+
+def test_bedrock_model_helpers(monkeypatch):
+    provider = load_model_provider(monkeypatch)
+    key = provider.bedrock_model_key("model-a")
+    assert key == "bedrock:model-a"
+    assert provider.is_bedrock_model(key)
+    assert provider.provider_model_id(key) == "model-a"
+    assert provider.display_model_name(key) == "Bedrock: model-a"
+    assert provider.display_model_name("llama3") == "llama3"
+
+
+def test_available_bedrock_models_requires_enabled(monkeypatch):
+    provider = load_model_provider(monkeypatch)
+    enabled = types.SimpleNamespace(bedrock_enabled=True, bedrock_model_ids=("a", "b"))
+    disabled = types.SimpleNamespace(bedrock_enabled=False, bedrock_model_ids=("a",))
+    assert provider.available_bedrock_models(enabled) == ["bedrock:a", "bedrock:b"]
+    assert provider.available_bedrock_models(disabled) == []
+
+
+def test_stream_model_routes_by_prefix(monkeypatch):
+    provider = load_model_provider(monkeypatch)
+    seen = {}
+
+    def fake_bedrock(messages, out_q, model_id=None, stop_event=None):
+        seen["bedrock"] = (messages, model_id, stop_event)
+        out_q.put(None)
+
+    def fake_ollama(messages, out_q, model=None, stop_event=None):
+        seen["ollama"] = (messages, model, stop_event)
+        out_q.put(None)
+
+    monkeypatch.setattr(provider, "stream_bedrock", fake_bedrock)
+    monkeypatch.setattr(provider, "stream_ollama", fake_ollama)
+    q = queue.Queue()
+    provider.stream_model([{"role": "user", "content": "u"}], q, model="bedrock:model-a")
+    assert seen["bedrock"][1] == "model-a"
+    assert q.get() is None
+
+    provider.stream_model([], q, model="llama3")
+    assert seen["ollama"][1] == "llama3"
+    assert q.get() is None

--- a/tests/test_settings_store.py
+++ b/tests/test_settings_store.py
@@ -79,6 +79,11 @@ def test_settings_store_round_trips_runtime_and_prompts(monkeypatch):
         serve_max_loaded_models=3,
         serve_flash_attention=False,
         serve_kv_cache_type="f16",
+        bedrock_enabled=True,
+        bedrock_aws_profile="dev",
+        bedrock_aws_region="us-west-2",
+        bedrock_model_ids=("model-a", "model-b"),
+        bedrock_max_tokens=8192,
     )
     store.save_runtime_settings(runtime)
     store.save_quick_prompts([
@@ -93,6 +98,11 @@ def test_settings_store_round_trips_runtime_and_prompts(monkeypatch):
     assert loaded_runtime.keep_alive == "20m"
     assert loaded_runtime.default_pull_model == "llama3.1"
     assert loaded_runtime.serve_env["OLLAMA_FLASH_ATTENTION"] == "0"
+    assert loaded_runtime.bedrock_enabled is True
+    assert loaded_runtime.bedrock_aws_profile == "dev"
+    assert loaded_runtime.bedrock_aws_region == "us-west-2"
+    assert loaded_runtime.bedrock_model_ids == ("model-a", "model-b")
+    assert loaded_runtime.bedrock_max_tokens == 8192
     assert store.get_quick_prompts() == OrderedDict([
         ("Explain", "Explain it"),
         ("Fix", "Fix it"),
@@ -108,6 +118,14 @@ def test_settings_store_defaults_when_empty(monkeypatch):
     defaults = module.default_runtime_settings()
     runtime = store.get_runtime_settings()
     assert runtime == defaults
+    assert runtime.bedrock_enabled is False
+    assert runtime.bedrock_model_ids == tuple(module.DEFAULT_BEDROCK_MODEL_IDS)
+    assert runtime.bedrock_model_ids[0] == "global.anthropic.claude-sonnet-4-6"
+
+
+def test_normalize_bedrock_model_ids_dedupes_commas_and_lines(monkeypatch):
+    module = load_settings_store(monkeypatch)
+    assert module.normalize_bedrock_model_ids("a, b\na\n\nc") == ("a", "b", "c")
 
 
 def test_fetch_ollama_models_prefers_env(monkeypatch):

--- a/ui/session_widget.py
+++ b/ui/session_widget.py
@@ -7,6 +7,7 @@ import subprocess
 import time
 
 from PySide6.QtCore import Qt, QTimer, Signal, QSettings
+from PySide6.QtGui import QColor, QPalette
 from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtWidgets import (
     QWidget,
@@ -18,6 +19,9 @@ from PySide6.QtWidgets import (
     QComboBox,
     QDialog,
     QMessageBox,
+    QStyle,
+    QStyleOptionComboBox,
+    QStylePainter,
 )
 from markdown_it import MarkdownIt
 
@@ -31,7 +35,8 @@ from chat_logic import (
 )
 from config import APP_NAME, APP_ORG, MODEL
 from history_store import HistoryStore
-from ollama_client import remember_local_server_process, stop_local_ollama_server, warm_up_model
+from model_provider import available_bedrock_models, display_model_name, is_bedrock_model, warm_up_selected_model
+from ollama_client import remember_local_server_process, stop_local_ollama_server
 from resources.html_template import HTML_TEMPLATE
 from settings_store import (
     SettingsStore,
@@ -80,6 +85,27 @@ from transcript_render import block_has_role, render_code_context_block, render_
 
 md = MarkdownIt()
 LEGACY_SETTINGS_ORG = "AskAboutSelection"
+BEDROCK_ACCENT = QColor("#56b6a7")
+DEFAULT_COMBO_COLOR = QColor("#eef2f6")
+
+
+class ModelComboBox(QComboBox):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._current_text_color = DEFAULT_COMBO_COLOR
+
+    def set_current_text_color(self, color: QColor) -> None:
+        self._current_text_color = color
+        self.update()
+
+    def paintEvent(self, event) -> None:
+        option = QStyleOptionComboBox()
+        self.initStyleOption(option)
+        option.palette.setColor(QPalette.ButtonText, self._current_text_color)
+        option.palette.setColor(QPalette.Text, self._current_text_color)
+        painter = QStylePainter(self)
+        painter.drawComplexControl(QStyle.CC_ComboBox, option)
+        painter.drawControl(QStyle.CE_ComboBoxLabel, option)
 
 
 class SessionWidget(QWidget):
@@ -150,8 +176,8 @@ class SessionWidget(QWidget):
         self.model_lbl.setProperty("role", "muted")
         self.model_lbl.setText(LABEL_MODEL)
 
-        self.model_combo = QComboBox()
-        self.model_combo.currentTextChanged.connect(self._on_model_changed)
+        self.model_combo = ModelComboBox()
+        self.model_combo.currentIndexChanged.connect(lambda _index: self._on_model_changed(self._selected_model()))
 
         # Refresh button
         self.refresh_btn = self._mk_btn(LABEL_REFRESH, self._setup_model_selector, variant="subtle")
@@ -239,23 +265,34 @@ class SessionWidget(QWidget):
 
     def _get_current_available_models(self) -> list[str]:
         """
-        Fetches the current list of Ollama models by calling the function
-        from config.py.
+        Fetches available local Ollama models and appends enabled Bedrock models.
         """
         self._runtime_settings = self._settings_store.get_runtime_settings()
-        return fetch_ollama_models(self._runtime_settings)
+        return [
+            *fetch_ollama_models(self._runtime_settings),
+            *available_bedrock_models(self._runtime_settings),
+        ]
 
     def _setup_model_selector(self):
         """
         Configures the model combobox and refresh button based on currently
         available Ollama models.
         """
-        current_model_list = self._get_current_available_models()
+        self._runtime_settings = self._settings_store.get_runtime_settings()
+        ollama_model_list = fetch_ollama_models(self._runtime_settings)
+        current_model_list = [
+            *ollama_model_list,
+            *available_bedrock_models(self._runtime_settings),
+        ]
         self.model_combo.blockSignals(True)
         self.model_combo.clear()
 
         if current_model_list:
-            self.model_combo.addItems(current_model_list)
+            for model in current_model_list:
+                self.model_combo.addItem(display_model_name(model), model)
+                item_index = self.model_combo.count() - 1
+                if is_bedrock_model(model):
+                    self.model_combo.setItemData(item_index, BEDROCK_ACCENT, Qt.ForegroundRole)
             saved_model = get_saved_chat_model(self._settings)
             if not saved_model:
                 saved_model = QSettings(LEGACY_SETTINGS_ORG, APP_NAME).value("chat/model", MODEL, type=str)
@@ -265,14 +302,16 @@ class SessionWidget(QWidget):
                 saved_model=saved_model,
                 default_model=MODEL,
             )
-            self.model_combo.setCurrentText(preferred)
+            preferred_index = self.model_combo.findData(preferred)
+            self.model_combo.setCurrentIndex(preferred_index if preferred_index >= 0 else 0)
             self.model_combo.setEnabled(True)
-            self._on_model_changed(self.model_combo.currentText())
+            self._on_model_changed(self._selected_model())
+            server_up = is_ollama_running(self._runtime_settings) if not ollama_model_list else True
             self.status.showMessage(STATUS_READY)
-            self.refresh_btn.setVisible(False)
-            self.run_ollama_btn.setVisible(False)
-            self.stop_ollama_btn.setVisible(True)
-            self.install_model_btn.setVisible(False)
+            self.refresh_btn.setVisible(not ollama_model_list)
+            self.run_ollama_btn.setVisible(not ollama_model_list and not server_up)
+            self.stop_ollama_btn.setVisible(bool(ollama_model_list) or server_up)
+            self.install_model_btn.setVisible(not ollama_model_list and server_up)
         else:
             server_up = is_ollama_running(self._runtime_settings)
             self.model_combo.addItem(NO_OLLAMA_MODELS_FOUND)
@@ -286,6 +325,7 @@ class SessionWidget(QWidget):
             self.run_ollama_btn.setVisible(not server_up)
             self.stop_ollama_btn.setVisible(server_up)
             self.install_model_btn.setVisible(server_up)
+        self._sync_model_combo_accent()
         self.model_combo.blockSignals(False)
 
     def _run_ollama_server(self):
@@ -339,7 +379,7 @@ class SessionWidget(QWidget):
     def _begin_ollama_refresh(self, *, attempts: int = 20, delay_ms: int = 1500):
         def _poll(remaining: int) -> None:
             self._setup_model_selector()
-            if self._get_current_available_models() or remaining <= 1:
+            if fetch_ollama_models(self._runtime_settings) or remaining <= 1:
                 return
             QTimer.singleShot(delay_ms, lambda: _poll(remaining - 1))
 
@@ -406,7 +446,7 @@ class SessionWidget(QWidget):
     def warm_up(self):
         model = self._selected_model()
         if model:
-            warm_up_model(model)
+            warm_up_selected_model(model)
 
     # conversation plumbing
     def _build_system_message(self):
@@ -443,7 +483,8 @@ class SessionWidget(QWidget):
         )
 
     def _selected_model(self) -> str:
-        model = self.model_combo.currentText().strip()
+        data = self.model_combo.currentData()
+        model = str(data).strip() if data is not None else self.model_combo.currentText().strip()
         return "" if not model or model == NO_OLLAMA_MODELS_FOUND else model
 
     def display_title(self) -> str:
@@ -511,7 +552,7 @@ class SessionWidget(QWidget):
         self._render_buf = []
         self._assistant_persisted = False
         self._generation_stopped = False
-        self.status.showMessage(status_generating(model))
+        self.status.showMessage(status_generating(display_model_name(model)))
         self._start_ts = time.time()
         self._chars = 0
         self._append_thinking_block()
@@ -535,8 +576,13 @@ class SessionWidget(QWidget):
         self._settings.setValue("chat/model", model)
         self._preferred_model = model
         self._session_model = model
+        self._sync_model_combo_accent()
         if self.session_id is not None and model and model != NO_OLLAMA_MODELS_FOUND:
             self.history_store.update_session_model(self.session_id, model)
+
+    def _sync_model_combo_accent(self) -> None:
+        text_color = BEDROCK_ACCENT if is_bedrock_model(self._selected_model()) else DEFAULT_COMBO_COLOR
+        self.model_combo.set_current_text_color(text_color)
 
     def _on_error(self, msg: str):
         if not should_handle_worker_signal(self._worker, self.sender()):
@@ -558,8 +604,8 @@ class SessionWidget(QWidget):
         self._worker = None
         elapsed = time.time() - self._start_ts
         cps = int(self._chars / elapsed) if elapsed > 0 else 0
-        model = getattr(self, "_active_model", self.model_combo.currentText())
-        self.status.showMessage(status_done(elapsed, self._chars, cps, model))
+        model = getattr(self, "_active_model", self._selected_model())
+        self.status.showMessage(status_done(elapsed, self._chars, cps, display_model_name(model)))
 
     def _finalize_assistant_message(self):
         if self._assistant_persisted:

--- a/ui/session_widget.py
+++ b/ui/session_widget.py
@@ -7,7 +7,7 @@ import subprocess
 import time
 
 from PySide6.QtCore import Qt, QTimer, Signal, QSettings
-from PySide6.QtGui import QColor, QPalette
+from PySide6.QtGui import QColor, QFont, QPalette, QPen
 from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtWidgets import (
     QWidget,
@@ -22,6 +22,8 @@ from PySide6.QtWidgets import (
     QStyle,
     QStyleOptionComboBox,
     QStylePainter,
+    QStyledItemDelegate,
+    QStyleOptionViewItem,
 )
 from markdown_it import MarkdownIt
 
@@ -35,7 +37,7 @@ from chat_logic import (
 )
 from config import APP_NAME, APP_ORG, MODEL
 from history_store import HistoryStore
-from model_provider import available_bedrock_models, display_model_name, is_bedrock_model, warm_up_selected_model
+from model_provider import available_bedrock_models, display_model_name, is_bedrock_model, provider_model_id, warm_up_selected_model
 from ollama_client import remember_local_server_process, stop_local_ollama_server
 from resources.html_template import HTML_TEMPLATE
 from settings_store import (
@@ -87,6 +89,48 @@ md = MarkdownIt()
 LEGACY_SETTINGS_ORG = "AskAboutSelection"
 BEDROCK_ACCENT = QColor("#56b6a7")
 DEFAULT_COMBO_COLOR = QColor("#eef2f6")
+SECTION_TEXT_COLOR = QColor("#8ea0b5")
+ITEM_KIND_ROLE = Qt.UserRole + 1
+MODEL_VALUE_ROLE = Qt.UserRole + 2
+ITEM_KIND_HEADER = "header"
+ITEM_KIND_MODEL = "model"
+
+
+class ModelComboDelegate(QStyledItemDelegate):
+    def paint(self, painter, option: QStyleOptionViewItem, index) -> None:
+        view_option = QStyleOptionViewItem(option)
+        self.initStyleOption(view_option, index)
+        kind = index.data(ITEM_KIND_ROLE)
+        if kind == ITEM_KIND_HEADER:
+            view_option.font = QFont(view_option.font)
+            view_option.font.setBold(True)
+            view_option.palette.setColor(QPalette.Text, SECTION_TEXT_COLOR)
+            view_option.palette.setColor(QPalette.WindowText, SECTION_TEXT_COLOR)
+            view_option.state &= ~QStyle.State_Selected
+            view_option.state &= ~QStyle.State_HasFocus
+        elif is_bedrock_model(str(index.data(MODEL_VALUE_ROLE) or "")):
+            view_option.palette.setColor(QPalette.Text, BEDROCK_ACCENT)
+            view_option.palette.setColor(QPalette.WindowText, BEDROCK_ACCENT)
+        super().paint(painter, view_option, index)
+        if kind == ITEM_KIND_HEADER and index.row() > 0:
+            painter.save()
+            painter.setPen(QPen(QColor("#313b45")))
+            painter.drawLine(
+                view_option.rect.left() + 8,
+                view_option.rect.top(),
+                view_option.rect.right() - 8,
+                view_option.rect.top(),
+            )
+            painter.restore()
+
+    def sizeHint(self, option: QStyleOptionViewItem, index) -> object:
+        size = super().sizeHint(option, index)
+        kind = index.data(ITEM_KIND_ROLE)
+        if kind == ITEM_KIND_HEADER:
+            size.setHeight(max(size.height(), 34))
+        else:
+            size.setHeight(max(size.height(), 28))
+        return size
 
 
 class ModelComboBox(QComboBox):
@@ -177,6 +221,7 @@ class SessionWidget(QWidget):
         self.model_lbl.setText(LABEL_MODEL)
 
         self.model_combo = ModelComboBox()
+        self.model_combo.setItemDelegate(ModelComboDelegate(self.model_combo))
         self.model_combo.currentIndexChanged.connect(lambda _index: self._on_model_changed(self._selected_model()))
 
         # Refresh button
@@ -288,11 +333,15 @@ class SessionWidget(QWidget):
         self.model_combo.clear()
 
         if current_model_list:
-            for model in current_model_list:
-                self.model_combo.addItem(display_model_name(model), model)
-                item_index = self.model_combo.count() - 1
-                if is_bedrock_model(model):
-                    self.model_combo.setItemData(item_index, BEDROCK_ACCENT, Qt.ForegroundRole)
+            if ollama_model_list:
+                self._add_model_section("Ollama Models")
+                for model in ollama_model_list:
+                    self._add_model_item(model, label=model)
+            bedrock_models = available_bedrock_models(self._runtime_settings)
+            if bedrock_models:
+                self._add_model_section("Bedrock Models")
+                for model in bedrock_models:
+                    self._add_model_item(model, label=provider_model_id(model))
             saved_model = get_saved_chat_model(self._settings)
             if not saved_model:
                 saved_model = QSettings(LEGACY_SETTINGS_ORG, APP_NAME).value("chat/model", MODEL, type=str)
@@ -483,8 +532,8 @@ class SessionWidget(QWidget):
         )
 
     def _selected_model(self) -> str:
-        data = self.model_combo.currentData()
-        model = str(data).strip() if data is not None else self.model_combo.currentText().strip()
+        data = self.model_combo.currentData(MODEL_VALUE_ROLE)
+        model = str(data).strip() if data is not None else ""
         return "" if not model or model == NO_OLLAMA_MODELS_FOUND else model
 
     def display_title(self) -> str:
@@ -583,6 +632,23 @@ class SessionWidget(QWidget):
     def _sync_model_combo_accent(self) -> None:
         text_color = BEDROCK_ACCENT if is_bedrock_model(self._selected_model()) else DEFAULT_COMBO_COLOR
         self.model_combo.set_current_text_color(text_color)
+
+    def _add_model_section(self, title: str) -> None:
+        self.model_combo.addItem(title, "")
+        item_index = self.model_combo.count() - 1
+        self.model_combo.setItemData(item_index, ITEM_KIND_HEADER, ITEM_KIND_ROLE)
+        self.model_combo.setItemData(item_index, "", MODEL_VALUE_ROLE)
+        model = self.model_combo.model()
+        if hasattr(model, "item"):
+            item = model.item(item_index)
+            if item is not None:
+                item.setEnabled(False)
+
+    def _add_model_item(self, model: str, *, label: str) -> None:
+        self.model_combo.addItem(label, model)
+        item_index = self.model_combo.count() - 1
+        self.model_combo.setItemData(item_index, ITEM_KIND_MODEL, ITEM_KIND_ROLE)
+        self.model_combo.setItemData(item_index, model, MODEL_VALUE_ROLE)
 
     def _on_error(self, msg: str):
         if not should_handle_worker_signal(self._worker, self.sender()):

--- a/ui/settings_dialog.py
+++ b/ui/settings_dialog.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QCheckBox,
+    QComboBox,
     QDialog,
     QDoubleSpinBox,
     QFrame,
@@ -12,6 +13,7 @@ from PySide6.QtWidgets import (
     QHeaderView,
     QLabel,
     QLineEdit,
+    QPlainTextEdit,
     QPushButton,
     QScrollArea,
     QSpinBox,
@@ -22,6 +24,12 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from aws_bedrock_discovery import (
+    available_aws_profiles,
+    available_bedrock_regions,
+    discover_bedrock_model_ids,
+    login_aws_profile,
+)
 from config import APP_AUTHOR_NAME, APP_DISPLAY_NAME
 from settings_store import DEFAULT_QUICK_PROMPTS, HistorySettings, RuntimeSettings, default_runtime_settings
 
@@ -114,15 +122,26 @@ class SettingsDialog(QDialog):
                 background: #2d3640;
                 color: #ffffff;
             }
-            QLineEdit, QSpinBox, QDoubleSpinBox, QTableWidget {
+            QComboBox, QLineEdit, QPlainTextEdit, QSpinBox, QDoubleSpinBox, QTableWidget {
                 background: #14181d;
                 color: #eef2f6;
                 border: 1px solid #313b45;
                 border-radius: 8px;
                 padding: 8px 10px;
             }
-            QLineEdit:focus, QSpinBox:focus, QDoubleSpinBox:focus, QTableWidget:focus {
+            QComboBox:focus, QLineEdit:focus, QPlainTextEdit:focus, QSpinBox:focus, QDoubleSpinBox:focus, QTableWidget:focus {
                 border-color: #56b6a7;
+            }
+            QComboBox::drop-down {
+                border: none;
+                width: 24px;
+            }
+            QComboBox QAbstractItemView {
+                background: #1f252c;
+                color: #eef2f6;
+                border: 1px solid #313b45;
+                selection-background-color: #2f8f81;
+                selection-color: #f8fffd;
             }
             QCheckBox {
                 spacing: 8px;
@@ -217,7 +236,7 @@ class SettingsDialog(QDialog):
         title = QLabel("Settings", header)
         title.setProperty("role", "title")
         body = QLabel(
-            f"Tune how {APP_DISPLAY_NAME} talks to Ollama and manage the quick actions that appear above every chat.",
+            f"Tune how {APP_DISPLAY_NAME} talks to models and manage the quick actions that appear above every chat.",
             header,
         )
         body.setWordWrap(True)
@@ -275,6 +294,14 @@ class SettingsDialog(QDialog):
                 "Set the default creativity, context size, and how long Ollama should keep models warm between requests.",
                 runtime,
                 rows_builder=self._build_generation_rows,
+            )
+        )
+        layout.addWidget(
+            self._build_form_card(
+                "AWS Bedrock",
+                "Enable cloud models through AWS Bedrock. Credentials are resolved by the AWS SDK from your configured profile, SSO session, or environment.",
+                runtime,
+                rows_builder=self._build_bedrock_rows,
             )
         )
         layout.addWidget(
@@ -459,6 +486,121 @@ class SettingsDialog(QDialog):
             self.kv_cache_edit,
             parent,
         )
+
+    def _build_bedrock_rows(self, rows, runtime: RuntimeSettings, parent: QWidget) -> None:
+        self.bedrock_enabled_check = QCheckBox("Enable AWS Bedrock models", parent)
+        self.bedrock_enabled_check.setChecked(runtime.bedrock_enabled)
+        self._add_setting_row(
+            rows,
+            self._make_form_label(
+                "Bedrock access",
+                "When enabled, configured Bedrock model IDs appear in the model dropdown.",
+                parent,
+            ),
+            self.bedrock_enabled_check,
+            parent,
+        )
+
+        self.bedrock_profile_combo = QComboBox(parent)
+        self.bedrock_profile_combo.setEditable(False)
+        self._populate_profile_combo(runtime.bedrock_aws_profile)
+        profile_row = QWidget(parent)
+        profile_layout = QHBoxLayout(profile_row)
+        profile_layout.setContentsMargins(0, 0, 0, 0)
+        profile_layout.setSpacing(8)
+        profile_layout.addWidget(self.bedrock_profile_combo, 1)
+        refresh_profiles_btn = QPushButton("Refresh Profiles", parent)
+        refresh_profiles_btn.clicked.connect(self._refresh_bedrock_profiles)
+        profile_layout.addWidget(refresh_profiles_btn)
+        login_btn = QPushButton("AWS SSO Login", parent)
+        login_btn.clicked.connect(self._login_bedrock_profile)
+        profile_layout.addWidget(login_btn)
+        self._add_setting_row(
+            rows,
+            self._make_form_label(
+                "AWS profile",
+                "Choose a configured AWS profile, or leave blank to use the default AWS SDK credential chain.",
+                parent,
+            ),
+            profile_row,
+            parent,
+        )
+
+        self.bedrock_region_combo = QComboBox(parent)
+        self.bedrock_region_combo.setEditable(False)
+        self._populate_region_combo(runtime.bedrock_aws_region)
+        region_row = QWidget(parent)
+        region_layout = QHBoxLayout(region_row)
+        region_layout.setContentsMargins(0, 0, 0, 0)
+        region_layout.setSpacing(8)
+        region_layout.addWidget(self.bedrock_region_combo, 1)
+        refresh_regions_btn = QPushButton("Refresh Regions", parent)
+        refresh_regions_btn.clicked.connect(self._refresh_bedrock_regions)
+        region_layout.addWidget(refresh_regions_btn)
+        self._add_setting_row(
+            rows,
+            self._make_form_label(
+                "AWS region",
+                "Region used for Bedrock Runtime requests.",
+                parent,
+            ),
+            region_row,
+            parent,
+        )
+
+        self.bedrock_models_edit = QPlainTextEdit(parent)
+        self.bedrock_models_edit.setPlainText("\n".join(runtime.bedrock_model_ids))
+        self.bedrock_models_edit.setPlaceholderText("us.anthropic.claude-sonnet-4-20250514-v1:0")
+        self.bedrock_models_edit.setMinimumHeight(96)
+        models_row = QWidget(parent)
+        models_layout = QVBoxLayout(models_row)
+        models_layout.setContentsMargins(0, 0, 0, 0)
+        models_layout.setSpacing(8)
+        models_layout.addWidget(self.bedrock_models_edit)
+        refresh_models_btn = QPushButton("Refresh Bedrock Models", parent)
+        refresh_models_btn.clicked.connect(self._refresh_bedrock_models)
+        models_layout.addWidget(refresh_models_btn, 0, Qt.AlignLeft)
+        self._add_setting_row(
+            rows,
+            self._make_form_label(
+                "Bedrock model IDs",
+                "Refresh to list inference profiles for the selected profile and region, or edit the list manually.",
+                parent,
+            ),
+            models_row,
+            parent,
+        )
+
+        self.bedrock_status_label = QLabel("Choose a profile and region, then refresh models.", parent)
+        self.bedrock_status_label.setWordWrap(True)
+        self.bedrock_status_label.setProperty("role", "section_body")
+        self._add_setting_row(
+            rows,
+            self._make_form_label(
+                "AWS status",
+                "Connection, login, and model discovery details appear here.",
+                parent,
+            ),
+            self.bedrock_status_label,
+            parent,
+        )
+
+        self.bedrock_max_tokens_spin = NoWheelSpinBox(parent)
+        self.bedrock_max_tokens_spin.setFocusPolicy(Qt.StrongFocus)
+        self.bedrock_max_tokens_spin.setRange(1, 200000)
+        self.bedrock_max_tokens_spin.setValue(runtime.bedrock_max_tokens)
+        self._add_setting_row(
+            rows,
+            self._make_form_label(
+                "Maximum output tokens",
+                "Caps the length of each Bedrock response.",
+                parent,
+            ),
+            self.bedrock_max_tokens_spin,
+            parent,
+        )
+        self.bedrock_profile_combo.currentIndexChanged.connect(self._on_bedrock_endpoint_changed)
+        self.bedrock_region_combo.currentIndexChanged.connect(self._on_bedrock_endpoint_changed)
 
     def _build_quick_prompts_tab(self, quick_prompts: OrderedDict[str, str]) -> QWidget:
         content = QWidget(self)
@@ -704,6 +846,12 @@ class SettingsDialog(QDialog):
         self.max_loaded_spin.setValue(defaults.serve_max_loaded_models)
         self.flash_attention_check.setChecked(defaults.serve_flash_attention)
         self.kv_cache_edit.setText(defaults.serve_kv_cache_type)
+        self.bedrock_enabled_check.setChecked(defaults.bedrock_enabled)
+        self._populate_profile_combo(defaults.bedrock_aws_profile)
+        self._populate_region_combo(defaults.bedrock_aws_region)
+        self.bedrock_models_edit.setPlainText("\n".join(defaults.bedrock_model_ids))
+        self.bedrock_max_tokens_spin.setValue(defaults.bedrock_max_tokens)
+        self.bedrock_status_label.setText("Restored AWS Bedrock defaults.")
 
     def get_runtime_settings(self) -> RuntimeSettings:
         return RuntimeSettings(
@@ -716,6 +864,15 @@ class SettingsDialog(QDialog):
             serve_max_loaded_models=self.max_loaded_spin.value(),
             serve_flash_attention=self.flash_attention_check.isChecked(),
             serve_kv_cache_type=self.kv_cache_edit.text().strip(),
+            bedrock_enabled=self.bedrock_enabled_check.isChecked(),
+            bedrock_aws_profile=self._combo_value(self.bedrock_profile_combo),
+            bedrock_aws_region=self._combo_value(self.bedrock_region_combo),
+            bedrock_model_ids=tuple(
+                model.strip()
+                for model in self.bedrock_models_edit.toPlainText().replace(",", "\n").splitlines()
+                if model.strip()
+            ),
+            bedrock_max_tokens=self.bedrock_max_tokens_spin.value(),
         )
 
     def get_quick_prompts(self) -> list[dict[str, str]]:
@@ -743,3 +900,68 @@ class SettingsDialog(QDialog):
 
     def should_clear_history(self) -> bool:
         return self._clear_history_requested
+
+    def _combo_value(self, combo: QComboBox) -> str:
+        data = combo.currentData()
+        if isinstance(data, str):
+            return data.strip()
+        return combo.currentText().strip()
+
+    def _populate_combo(self, combo: QComboBox, values: list[tuple[str, str]], selected: str) -> None:
+        current = selected.strip()
+        combo.blockSignals(True)
+        combo.clear()
+        seen: set[str] = set()
+        for label, value in values:
+            cleaned_value = (value or "").strip()
+            if cleaned_value in seen:
+                continue
+            seen.add(cleaned_value)
+            combo.addItem(label, cleaned_value)
+        if current and current not in seen:
+            combo.insertItem(0, current, current)
+        index = combo.findData(current)
+        if index >= 0:
+            combo.setCurrentIndex(index)
+        elif combo.count():
+            combo.setCurrentIndex(0)
+        combo.blockSignals(False)
+
+    def _populate_profile_combo(self, selected: str) -> None:
+        values = [("(Default credential chain)", "")]
+        values.extend((profile, profile) for profile in available_aws_profiles())
+        self._populate_combo(self.bedrock_profile_combo, values, selected)
+
+    def _populate_region_combo(self, selected: str) -> None:
+        values = [(region, region) for region in available_bedrock_regions()]
+        self._populate_combo(self.bedrock_region_combo, values, selected)
+
+    def _refresh_bedrock_profiles(self) -> None:
+        current = self._combo_value(self.bedrock_profile_combo)
+        self._populate_profile_combo(current)
+        self.bedrock_status_label.setText("Refreshed AWS profiles.")
+
+    def _refresh_bedrock_regions(self) -> None:
+        current = self._combo_value(self.bedrock_region_combo)
+        self._populate_region_combo(current)
+        self.bedrock_status_label.setText("Refreshed Bedrock regions.")
+
+    def _refresh_bedrock_models(self) -> None:
+        result = discover_bedrock_model_ids(
+            self._combo_value(self.bedrock_profile_combo),
+            self._combo_value(self.bedrock_region_combo),
+        )
+        self.bedrock_models_edit.setPlainText("\n".join(result.model_ids))
+        self.bedrock_status_label.setText(result.status_message)
+
+    def _on_bedrock_endpoint_changed(self, _index: int) -> None:
+        self._refresh_bedrock_models()
+
+    def _login_bedrock_profile(self) -> None:
+        success, message = login_aws_profile(
+            self._combo_value(self.bedrock_profile_combo),
+            self._combo_value(self.bedrock_region_combo),
+        )
+        self.bedrock_status_label.setText(message)
+        if success:
+            self._refresh_bedrock_models()

--- a/workers/chat_worker.py
+++ b/workers/chat_worker.py
@@ -5,7 +5,7 @@ import threading
 from PySide6.QtCore import QThread, Signal
 
 from config import MODEL
-from ollama_client import stream_ollama
+from model_provider import stream_model
 
 
 class ChatWorker(QThread):
@@ -28,7 +28,7 @@ class ChatWorker(QThread):
         q: queue.Queue[str | None] = queue.Queue()
 
         def worker() -> None:
-            stream_ollama(self.messages, q, model=self.model, stop_event=self._stop_event)
+            stream_model(self.messages, q, model=self.model, stop_event=self._stop_event)
 
         t = threading.Thread(target=worker, daemon=True)
         t.start()

--- a/workers/title_worker.py
+++ b/workers/title_worker.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from PySide6.QtCore import QThread, Signal
 
 from config import MODEL
-from ollama_client import generate_chat_title
+from model_provider import generate_model_chat_title
 
 
 class TitleWorker(QThread):
@@ -24,7 +24,7 @@ class TitleWorker(QThread):
         self.file_path = file_path
 
     def run(self) -> None:
-        title = generate_chat_title(
+        title = generate_model_chat_title(
             self.messages,
             model=self.model,
             file_name=self.file_name,


### PR DESCRIPTION
## Summary
- add optional AWS Bedrock support alongside Ollama with provider-based routing
- add Bedrock settings, AWS profile/region discovery, SSO login flow, and filtered Bedrock model refresh
- add Bedrock request/error handling, model dropdown differentiation, launcher cleanup, and README setup docs

## Testing
- pytest

## Notes
- the Raycast launcher file under `/Users/ajamal/Documents/Raycast Extensions/` was updated locally on the machine but is outside this Git repository, so it is not part of this PR